### PR TITLE
Fix #3: Highlight all lyrics lines in plain lyrics

### DIFF
--- a/app-rn/src/screens/PlayerScreen.tsx
+++ b/app-rn/src/screens/PlayerScreen.tsx
@@ -369,7 +369,7 @@ export default function PlayerScreen({ navigation }: Props) {
   const renderLyricLine = ({ item, index }: { item: StudyUnit; index: number }) => (
     <LyricLine
       studyUnit={item}
-      isActive={isSynced && index === currentLineIndex}
+      isActive={!isSynced || index === currentLineIndex}
       onTokenPress={handleTokenPress}
     />
   );


### PR DESCRIPTION
Fixes #3

## Summary
- Changed `isActive` condition in `PlayerScreen.tsx` from `isSynced && index === currentLineIndex` to `!isSynced || index === currentLineIndex`
- Plain lyrics now show all lines as active (not dimmed), matching the expected behavior
- Synced lyrics behavior is unchanged — only the current line is highlighted

## Test plan
- [ ] Open a song with **plain** (non-synced) lyrics → all lines should appear in normal (non-dimmed) style
- [ ] Open a song with **synced** lyrics → only the current line should be highlighted, others dimmed (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)