### PR TITLE
Fix #2: Validate artist name in LRCLIB search

### DIFF
--- a/backend/src/main/kotlin/com/japanese/vocabulary/song/client/lrclib/LrclibClient.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/song/client/lrclib/LrclibClient.kt
@@ -4,6 +4,7 @@ import com.japanese.vocabulary.song.client.LyricProvider
 import com.japanese.vocabulary.song.client.LyricsResult
 import com.japanese.vocabulary.song.client.NormalizedSongQuery
 import com.japanese.vocabulary.song.client.lrclib.dto.LrclibResponse
+import kotlin.math.abs
 import org.slf4j.LoggerFactory
 import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
@@ -30,7 +31,7 @@ class LrclibClient : LyricProvider {
                 ?.let { return it }
 
             // 2차: 원본 제목으로 search
-            fetchFromSearch(query.originalTitle)
+            fetchFromSearch(query.originalTitle, query)
                 ?.let { return it }
 
             // 3차: 정규화된 값이 다를 때만 추가 시도
@@ -41,7 +42,7 @@ class LrclibClient : LyricProvider {
                 }
 
                 if (query.normalizedTitle != query.originalTitle) {
-                    fetchFromSearch(query.normalizedTitle)
+                    fetchFromSearch(query.normalizedTitle, query)
                         ?.let { return it }
                 }
             }
@@ -76,7 +77,7 @@ class LrclibClient : LyricProvider {
         return toResult(response)
     }
 
-    private fun fetchFromSearch(title: String): LyricsResult? {
+    private fun fetchFromSearch(title: String, query: NormalizedSongQuery): LyricsResult? {
         val results = try {
             webClient.get()
                 .uri { it.path("/api/search").queryParam("q", title).build() }
@@ -89,7 +90,28 @@ class LrclibClient : LyricProvider {
             return null
         }
 
-        return results.firstNotNullOfOrNull { toResult(it) }
+        val normalizedParts = query.artistParts.map { it.lowercase() }
+
+        // Tier 1: artist name match
+        for (result in results) {
+            val resultArtist = result.artistName.lowercase()
+            if (normalizedParts.any { part -> resultArtist.contains(part) }) {
+                toResult(result)?.let { return it }
+            }
+        }
+
+        // Tier 2: duration match (handles cross-script artist names)
+        val queryDuration = query.durationSeconds
+        if (queryDuration != null) {
+            for (result in results) {
+                val resultDuration = result.duration
+                if (resultDuration != null && abs(queryDuration - resultDuration) <= 3) {
+                    toResult(result)?.let { return it }
+                }
+            }
+        }
+
+        return null
     }
 
     private fun toResult(response: LrclibResponse): LyricsResult? {


### PR DESCRIPTION
Fixes #2

## Summary
- Add artist name validation to `LrclibClient.fetchFromSearch()` to prevent returning lyrics from a different artist who shares the same song title
- Tier 1: case-insensitive `contains` match against `query.artistParts` (handles same-script names)
- Tier 2: duration match within ±3 seconds (handles cross-script names like "あいみょん" vs "Aimyon")
- If neither tier matches, returns `null` so VocaDB fallback proceeds correctly

## Test plan
- [ ] Search "内緒のピアス - バースデイ" → should NOT return lyrics for "People In The Box - バースデイ"
- [ ] Search a song where LRCLIB `/api/get` exact match works → no change in behavior
- [ ] Search a song with cross-script artist name (e.g., あいみょん) → duration fallback should find correct lyrics
- [ ] Search a song not on LRCLIB → should fall through to VocaDB as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)