### PR TITLE
Fix #2: Validate artist in LRCLIB search results

### DIFF
--- a/backend/src/main/kotlin/com/japanese/vocabulary/song/client/lrclib/LrclibClient.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/song/client/lrclib/LrclibClient.kt
@@ -9,6 +9,7 @@ import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import kotlin.math.abs
 
 @Component
 @Order(1)
@@ -30,7 +31,7 @@ class LrclibClient : LyricProvider {
                 ?.let { return it }
 
             // 2차: 원본 제목으로 search
-            fetchFromSearch(query.originalTitle)
+            fetchFromSearch(query.originalTitle, query)
                 ?.let { return it }
 
             // 3차: 정규화된 값이 다를 때만 추가 시도
@@ -41,7 +42,7 @@ class LrclibClient : LyricProvider {
                 }
 
                 if (query.normalizedTitle != query.originalTitle) {
-                    fetchFromSearch(query.normalizedTitle)
+                    fetchFromSearch(query.normalizedTitle, query)
                         ?.let { return it }
                 }
             }
@@ -76,7 +77,7 @@ class LrclibClient : LyricProvider {
         return toResult(response)
     }
 
-    private fun fetchFromSearch(title: String): LyricsResult? {
+    private fun fetchFromSearch(title: String, query: NormalizedSongQuery): LyricsResult? {
         val results = try {
             webClient.get()
                 .uri { it.path("/api/search").queryParam("q", title).build() }
@@ -89,7 +90,29 @@ class LrclibClient : LyricProvider {
             return null
         }
 
-        return results.firstNotNullOfOrNull { toResult(it) }
+        val normalizedParts = query.artistParts.map { it.lowercase() }
+
+        // Tier 1: artist name match
+        for (response in results) {
+            val responseArtist = response.artistName.lowercase()
+            val artistMatches = normalizedParts.any { part -> responseArtist.contains(part) }
+            if (artistMatches) {
+                toResult(response)?.let { return it }
+            }
+        }
+
+        // Tier 2: duration match (handles cross-script artist names like あいみょん vs Aimyon)
+        val queryDuration = query.durationSeconds
+        if (queryDuration != null) {
+            for (response in results) {
+                val responseDuration = response.duration
+                if (responseDuration != null && abs(queryDuration - responseDuration) <= 3) {
+                    toResult(response)?.let { return it }
+                }
+            }
+        }
+
+        return null
     }
 
     private fun toResult(response: LrclibResponse): LyricsResult? {


### PR DESCRIPTION
Fixes #2

## Summary
- Add artist name and duration validation to `LrclibClient.fetchFromSearch()` to prevent song/lyric mismatches
- Tier 1: case-insensitive artist name partial match (same approach as VocaDB validation)
- Tier 2: duration match (≤3s tolerance) as fallback for cross-script artist names (e.g., あいみょん vs Aimyon)
- Unmatched results return `null`, allowing correct fallback to VocaDB

## Test plan
- [ ] Search "内緒のピアス - バースデイ" → should NOT return "People In The Box" lyrics from LRCLIB
- [ ] Search a song where LRCLIB exact match works → no behavior change
- [ ] Search a song with cross-script artist name (e.g., あいみょん) → duration-based match should work
- [ ] Search a song not in LRCLIB at all → should fall through to VocaDB as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)