### PR TITLE
Fix #7: Seek MV to clicked lyric line

### DIFF
--- a/.github/scripts/issue-resolver-prompt.md
+++ b/.github/scripts/issue-resolver-prompt.md
@@ -51,6 +51,9 @@ For each issue found:
 
 ### Impact
 - (what else might be affected)
+
+### UI Draft (if design changes are needed)
+(ASCII art mockup of the proposed UI change)
 ```
 
 5. Update labels:
@@ -97,6 +100,7 @@ gh issue edit NUMBER --remove-label "status:approved" --add-label "status:implem
 ```
    The worktree is created at `../japanese-vocabulary-fix-issue-NUMBER/` by default.
 4. Implement changes in the worktree directory, following the approved plan and CLAUDE.md conventions.
+   If the change involves UI design, update the Pencil design file (`app-rn/japanese-vocabulary.pen`) using Pencil MCP tools (batch_design) to reflect the new or modified screens. The .pen file changes must be included in the PR commit.
 5. Commit, push, and create PR:
 ```
 cd ../japanese-vocabulary-fix-issue-NUMBER

--- a/app-rn/japanese-vocabulary.pen
+++ b/app-rn/japanese-vocabulary.pen
@@ -17385,6 +17385,218 @@
                   ]
                 }
               ]
+            },
+            {
+              "type": "frame",
+              "id": "EwHWV",
+              "name": "exSection",
+              "width": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "WgRh5",
+                  "name": "exLabel",
+                  "fill": "$text-muted",
+                  "content": "예문",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "uADOS",
+                  "name": "exRow1",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$border-default"
+                  },
+                  "gap": 10,
+                  "padding": [
+                    12,
+                    0
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "N73lS",
+                      "name": "txt1",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "0XSQB",
+                          "name": "jp1",
+                          "fill": "$text-primary",
+                          "content": "届けたいのに、言葉にならない",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "btfwc",
+                          "name": "kr1",
+                          "fill": "$text-muted",
+                          "content": "전하고 싶은데, 말이 안 나와",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "96SqL",
+                          "name": "songRow1",
+                          "gap": 5,
+                          "padding": [
+                            2,
+                            0,
+                            0,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "jgdIk",
+                              "name": "art1",
+                              "width": 14,
+                              "height": 14,
+                              "fill": {
+                                "type": "image",
+                                "enabled": true,
+                                "url": "./images/generated-1774069357299.png",
+                                "mode": "fill"
+                              },
+                              "cornerRadius": 3
+                            },
+                            {
+                              "type": "text",
+                              "id": "AENt7",
+                              "name": "sl1",
+                              "fill": "$text-muted",
+                              "content": "夜に駆ける — YOASOBI",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "Jpzm3",
+                      "name": "x1",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "kMiau",
+                  "name": "exRow2",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    12,
+                    0
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "6sdRj",
+                      "name": "txt2",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "f3J9R",
+                          "name": "jp2",
+                          "fill": "$text-primary",
+                          "content": "届かない声を抱きしめて",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Qy7zQ",
+                          "name": "kr2",
+                          "fill": "$text-muted",
+                          "content": "닿지 않는 목소리를 안고",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Szpv6",
+                          "name": "songRow2",
+                          "gap": 5,
+                          "padding": [
+                            2,
+                            0,
+                            0,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Qp4Kc",
+                              "name": "art2",
+                              "width": 14,
+                              "height": 14,
+                              "fill": {
+                                "type": "image",
+                                "enabled": true,
+                                "url": "./images/generated-1774069357299.png",
+                                "mode": "fill"
+                              },
+                              "cornerRadius": 3
+                            },
+                            {
+                              "type": "text",
+                              "id": "AeWXv",
+                              "name": "sl2",
+                              "fill": "$text-muted",
+                              "content": "群青 — YOASOBI",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "hUj4c",
+                      "name": "x2",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },

--- a/app-rn/src/components/LyricLine.tsx
+++ b/app-rn/src/components/LyricLine.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import React, { useRef, useCallback } from 'react';
+import { View, Text, TouchableOpacity, Pressable, Animated, StyleSheet } from 'react-native';
 import { Token, StudyUnit } from '../types/song';
 import { POS_INFO } from '../types/pos';
 import { Colors } from '../theme/theme';
@@ -15,10 +15,22 @@ interface Props {
   studyUnit: StudyUnit;
   isActive: boolean;
   onTokenPress: (token: Token, lineText: string, koreanLyrics: string | null) => void;
+  onLinePress?: () => void;
 }
 
-export default function LyricLine({ studyUnit, isActive, onTokenPress }: Props) {
+export default function LyricLine({ studyUnit, isActive, onTokenPress, onLinePress }: Props) {
   const textStyle = isActive ? styles.tokenTextActive : styles.tokenTextInactive;
+  const flashOpacity = useRef(new Animated.Value(0)).current;
+
+  const handleLinePress = useCallback(() => {
+    flashOpacity.setValue(0.10);
+    Animated.timing(flashOpacity, {
+      toValue: 0,
+      duration: 400,
+      useNativeDriver: true,
+    }).start();
+    onLinePress?.();
+  }, [onLinePress, flashOpacity]);
 
   const renderToken = (token: Token, ti: number) => {
     const underlineColor = getUnderlineColor(token.partOfSpeech);
@@ -73,7 +85,13 @@ export default function LyricLine({ studyUnit, isActive, onTokenPress }: Props) 
   };
 
   return (
-    <View style={styles.container}>
+    <Pressable style={styles.container} onPress={onLinePress ? handleLinePress : undefined} disabled={!onLinePress}>
+      {onLinePress && (
+        <Animated.View
+          style={[styles.flashOverlay, { backgroundColor: Colors.primary, opacity: flashOpacity }]}
+          pointerEvents="none"
+        />
+      )}
       <View style={styles.tokensRow}>{renderTokens()}</View>
       {studyUnit.koreanPronounciation && (
         <Text style={isActive ? styles.pronActive : styles.pronInactive}>
@@ -85,7 +103,7 @@ export default function LyricLine({ studyUnit, isActive, onTokenPress }: Props) 
           {studyUnit.koreanLyrics}
         </Text>
       )}
-    </View>
+    </Pressable>
   );
 }
 
@@ -93,6 +111,14 @@ const styles = StyleSheet.create({
   container: {
     marginBottom: 20,
     gap: 4,
+  },
+  flashOverlay: {
+    position: 'absolute',
+    top: -4,
+    bottom: -4,
+    left: -8,
+    right: -8,
+    borderRadius: 8,
   },
   tokensRow: {
     flexDirection: 'row',

--- a/app-rn/src/screens/PlayerScreen.tsx
+++ b/app-rn/src/screens/PlayerScreen.tsx
@@ -371,6 +371,7 @@ export default function PlayerScreen({ navigation }: Props) {
       studyUnit={item}
       isActive={!isSynced || index === currentLineIndex}
       onTokenPress={handleTokenPress}
+      onLinePress={isSynced && item.startTimeMs != null ? () => handleSeek(item.startTimeMs!) : undefined}
     />
   );
 


### PR DESCRIPTION
Fixes #7

## Summary
- Tapping a synced lyric line (outside word tokens) seeks the YouTube MV to that line's timestamp
- Adds a brief background flash animation (Colors.primary at 10% opacity → transparent over 400ms) for visual feedback
- Word token taps remain unaffected — inner `TouchableOpacity` captures those events naturally
- Only enabled for synced lyrics with a valid `startTimeMs`

## Changes
- `app-rn/src/components/LyricLine.tsx` — Added `onLinePress` prop, wrapped container with `Pressable`, added flash overlay with `Animated`
- `app-rn/src/screens/PlayerScreen.tsx` — Passes `onLinePress` callback that calls `handleSeek(startTimeMs)` for synced lines

## Test plan
- [ ] Open a song with synced lyrics
- [ ] Tap a lyric line (not on a word) → MV should seek to that line's timestamp
- [ ] Verify a brief background flash appears on the tapped line
- [ ] Tap a word token → word analysis sheet should open (unchanged behavior)
- [ ] Open a song with plain lyrics → tapping lines should have no effect