### PR TITLE
Fix #10: Return 204 instead of 404 in /api/words/by-text

### DIFF
--- a/app-rn/src/api/wordApi.ts
+++ b/app-rn/src/api/wordApi.ts
@@ -24,14 +24,9 @@ export const wordApi = {
   },
 
   async getByText(japanese: string): Promise<WordDetailResponse | null> {
-    try {
-      const { data } = await client.get<WordDetailResponse>('/api/words/by-text', {
-        params: { japanese },
-      });
-      return data;
-    } catch (e: any) {
-      if (e.response?.status === 404) return null;
-      throw e;
-    }
+    const resp = await client.get<WordDetailResponse>('/api/words/by-text', {
+      params: { japanese },
+    });
+    return resp.status === 204 ? null : resp.data;
   },
 };

--- a/backend/src/main/kotlin/com/japanese/vocabulary/word/controller/WordController.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/word/controller/WordController.kt
@@ -46,6 +46,6 @@ class WordController(
         val userId = currentUserId()
         val result = wordService.getWord(userId, japanese)
         return if (result != null) ResponseEntity.ok(result)
-        else ResponseEntity.notFound().build()
+        else ResponseEntity.noContent().build()
     }
 }


### PR DESCRIPTION
Fixes #10

## Summary
- Backend: Changed `GET /api/words/by-text` to return HTTP 204 (No Content) instead of 404 when no saved word is found
- Frontend: Removed try/catch 404 workaround in `wordApi.getByText()`, now checks for 204 status directly

## Test plan
- [ ] Call `GET /api/words/by-text?japanese=未知` for a word not in the user's vocabulary → expect 204 with empty body
- [ ] Call `GET /api/words/by-text?japanese=食べる` for a saved word → expect 200 with `WordDetailResponse`
- [ ] Open PlayerScreen, tap a token not yet saved → WordAnalysisSheet shows "new word" state (no errors in console)
- [ ] Tap a token that was previously saved → WordAnalysisSheet shows existing word details

🤖 Generated with [Claude Code](https://claude.com/claude-code)