### PR TITLE
Fix #12: Add feature to save all words in a song

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,14 @@ PENDING/PROCESSING 엔트리 조회 (최대 5개) → 병렬 처리:
 - Backend: 도메인 기반 패키지 (`auth / song / word / flashcard / deck / user`), WebClient for external APIs
 - App: Zustand stores (도메인별), Axios with auth interceptor, `StyleSheet.create()` co-located with components
 
+### Frontend Performance Rules
+
+- **Zustand 셀렉터 필수**: `useStore()` 금지. 반드시 `useShallow` 또는 개별 셀렉터 사용 (`useStore(s => s.field)` / `useStore(useShallow(s => ({ a: s.a, b: s.b })))`)
+- **React.memo**: 리스트 아이템, 반복 렌더링되는 컴포넌트에 적용 (예: `LyricLine`, `RatingButtonRow`)
+- **useCallback**: 자식 컴포넌트에 전달하는 이벤트 핸들러는 `useCallback`으로 감싸서 memo가 동작하도록
+- **인라인 함수 금지**: `renderItem` 안에서 `() => handler(item.id)` 같은 인라인 콜백 대신, 자식 컴포넌트가 필요한 값을 prop으로 받아 내부에서 호출
+- **useMemo**: 배열 순회(`some`, `every`, `reduce`) 등 비용이 있는 렌더 경로 계산에 적용
+
 ## Execution Rules
 
 - Treat the sprint request as the source of truth for current priorities

--- a/app-rn/japanese-vocabulary.pen
+++ b/app-rn/japanese-vocabulary.pen
@@ -218,6 +218,39 @@
                       "fontFamily": "Inter",
                       "fontSize": 15,
                       "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UwaPh",
+                      "name": "entryBtn",
+                      "fill": "#4F46E512",
+                      "cornerRadius": 20,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Z9wDM",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "list",
+                          "iconFontFamily": "feather",
+                          "fill": "$accent-primary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "tAjWK",
+                          "fill": "$accent-primary",
+                          "content": "전체 단어 담기",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
                     }
                   ]
                 },
@@ -230,7 +263,7 @@
                   "height": "fit_content",
                   "width": "fill_container",
                   "x": 0,
-                  "y": 115,
+                  "y": 156,
                   "padding": [
                     8,
                     24,
@@ -12098,6 +12131,20 @@
           "x": 24,
           "y": 73
         },
+        "UwaPh": {
+          "x": 24,
+          "y": 97,
+          "width": "fit_content",
+          "height": "fit_content"
+        },
+        "Z9wDM": {
+          "x": 14,
+          "y": 9.5
+        },
+        "tAjWK": {
+          "x": 36,
+          "y": 8
+        },
         "X5SPb": {
           "type": "frame",
           "id": "gO4aU",
@@ -12446,6 +12493,20 @@
           "x": 24,
           "y": 73
         },
+        "UwaPh": {
+          "x": 24,
+          "y": 97,
+          "width": "fit_content",
+          "height": "fit_content"
+        },
+        "Z9wDM": {
+          "x": 14,
+          "y": 9.5
+        },
+        "tAjWK": {
+          "x": 36,
+          "y": 8
+        },
         "X5SPb": {
           "type": "frame",
           "id": "4hAdH",
@@ -12782,6 +12843,20 @@
         "8IBFX": {
           "x": 24,
           "y": 73
+        },
+        "UwaPh": {
+          "x": 24,
+          "y": 97,
+          "width": "fit_content",
+          "height": "fit_content"
+        },
+        "Z9wDM": {
+          "x": 14,
+          "y": 9.5
+        },
+        "tAjWK": {
+          "x": 36,
+          "y": 8
         },
         "X5SPb": {
           "type": "frame",
@@ -13207,9 +13282,24 @@
                   "x": 24,
                   "y": 73
                 },
+                "UwaPh": {
+                  "x": 24,
+                  "y": 97,
+                  "width": "fit_content",
+                  "height": "fit_content"
+                },
+                "Z9wDM": {
+                  "x": 14,
+                  "y": 9.5
+                },
+                "tAjWK": {
+                  "x": 36,
+                  "y": 8
+                },
                 "X5SPb": {
                   "width": "fill_container",
-                  "height": "fit_content"
+                  "height": "fit_content",
+                  "y": 156
                 },
                 "X5SPb/LwygQ": {
                   "width": "fill_container",
@@ -13516,7 +13606,8 @@
                       "x": 44
                     },
                     "hGY8J": {
-                      "width": "fill_container"
+                      "width": "fill_container",
+                      "y": 0
                     },
                     "UkLR2": {
                       "x": 15,
@@ -13550,9 +13641,24 @@
                       "x": 24,
                       "y": 73
                     },
+                    "UwaPh": {
+                      "x": 24,
+                      "y": 97,
+                      "width": "fit_content",
+                      "height": "fit_content"
+                    },
+                    "Z9wDM": {
+                      "x": 14,
+                      "y": 9.5
+                    },
+                    "tAjWK": {
+                      "x": 36,
+                      "y": 8
+                    },
                     "X5SPb": {
                       "width": "fill_container",
-                      "height": "fit_content"
+                      "height": "fit_content",
+                      "y": 156
                     },
                     "X5SPb/LwygQ": {
                       "width": "fill_container",
@@ -13977,7 +14083,8 @@
                       "x": 44
                     },
                     "hGY8J": {
-                      "width": "fill_container"
+                      "width": "fill_container",
+                      "y": 0
                     },
                     "UkLR2": {
                       "x": 15,
@@ -14011,9 +14118,24 @@
                       "x": 24,
                       "y": 73
                     },
+                    "UwaPh": {
+                      "x": 24,
+                      "y": 97,
+                      "width": "fit_content",
+                      "height": "fit_content"
+                    },
+                    "Z9wDM": {
+                      "x": 14,
+                      "y": 9.5
+                    },
+                    "tAjWK": {
+                      "x": 36,
+                      "y": 8
+                    },
                     "X5SPb": {
                       "width": "fill_container",
-                      "height": "fit_content"
+                      "height": "fit_content",
+                      "y": 156
                     },
                     "X5SPb/LwygQ": {
                       "width": "fill_container",
@@ -14456,9 +14578,24 @@
                   "x": 24,
                   "y": 73
                 },
+                "UwaPh": {
+                  "x": 24,
+                  "y": 97,
+                  "width": "fit_content",
+                  "height": "fit_content"
+                },
+                "Z9wDM": {
+                  "x": 14,
+                  "y": 9.5
+                },
+                "tAjWK": {
+                  "x": 36,
+                  "y": 8
+                },
                 "X5SPb": {
                   "width": "fill_container",
-                  "height": "fit_content"
+                  "height": "fit_content",
+                  "y": 156
                 },
                 "X5SPb/LwygQ": {
                   "width": "fill_container",
@@ -14801,9 +14938,24 @@
                       "x": 24,
                       "y": 73
                     },
+                    "UwaPh": {
+                      "x": 24,
+                      "y": 97,
+                      "width": "fit_content",
+                      "height": "fit_content"
+                    },
+                    "Z9wDM": {
+                      "x": 14,
+                      "y": 9.5
+                    },
+                    "tAjWK": {
+                      "x": 36,
+                      "y": 8
+                    },
                     "X5SPb": {
                       "width": "fill_container",
-                      "height": "fit_content"
+                      "height": "fit_content",
+                      "y": 156
                     },
                     "X5SPb/LwygQ": {
                       "width": "fill_container",
@@ -15830,9 +15982,24 @@
               "x": 24,
               "y": 73
             },
+            "UwaPh": {
+              "x": 24,
+              "y": 97,
+              "width": "fit_content",
+              "height": "fit_content"
+            },
+            "Z9wDM": {
+              "x": 14,
+              "y": 9.5
+            },
+            "tAjWK": {
+              "x": 36,
+              "y": 8
+            },
             "X5SPb": {
               "width": "fill_container",
-              "height": "fit_content"
+              "height": "fit_content",
+              "y": 156
             },
             "X5SPb/LwygQ": {
               "width": "fill_container",
@@ -19683,9 +19850,24 @@
               "x": 24,
               "y": 73
             },
+            "UwaPh": {
+              "x": 24,
+              "y": 97,
+              "width": "fit_content",
+              "height": "fit_content"
+            },
+            "Z9wDM": {
+              "x": 14,
+              "y": 9.5
+            },
+            "tAjWK": {
+              "x": 36,
+              "y": 8
+            },
             "X5SPb": {
               "width": "fill_container",
-              "height": "fit_content"
+              "height": "fit_content",
+              "y": 156
             },
             "X5SPb/LwygQ": {
               "width": "fill_container",
@@ -20391,9 +20573,24 @@
               "x": 24,
               "y": 73
             },
+            "UwaPh": {
+              "x": 24,
+              "y": 97,
+              "width": "fit_content",
+              "height": "fit_content"
+            },
+            "Z9wDM": {
+              "x": 14,
+              "y": 9.5
+            },
+            "tAjWK": {
+              "x": 36,
+              "y": 8
+            },
             "X5SPb": {
               "width": "fill_container",
-              "height": "fit_content"
+              "height": "fit_content",
+              "y": 156
             },
             "X5SPb/LwygQ": {
               "width": "fill_container",
@@ -21101,9 +21298,24 @@
               "x": 24,
               "y": 73
             },
+            "UwaPh": {
+              "x": 24,
+              "y": 97,
+              "width": "fit_content",
+              "height": "fit_content"
+            },
+            "Z9wDM": {
+              "x": 14,
+              "y": 9.5
+            },
+            "tAjWK": {
+              "x": 36,
+              "y": 8
+            },
             "X5SPb": {
               "width": "fill_container",
-              "height": "fit_content"
+              "height": "fit_content",
+              "y": 156
             },
             "X5SPb/LwygQ": {
               "width": "fill_container",
@@ -21833,9 +22045,24 @@
                   "x": 24,
                   "y": 73
                 },
+                "UwaPh": {
+                  "x": 24,
+                  "y": 97,
+                  "width": "fit_content",
+                  "height": "fit_content"
+                },
+                "Z9wDM": {
+                  "x": 14,
+                  "y": 9.5
+                },
+                "tAjWK": {
+                  "x": 36,
+                  "y": 8
+                },
                 "X5SPb": {
                   "width": "fill_container",
-                  "height": "fit_content"
+                  "height": "fit_content",
+                  "y": 156
                 },
                 "X5SPb/LwygQ": {
                   "width": "fill_container",
@@ -22598,76 +22825,56 @@
     },
     {
       "type": "frame",
-      "id": "sz5hR",
-      "x": 399,
-      "y": 6020,
-      "name": "7a. My Page Tab (Redesigned)",
+      "id": "HzKlt",
+      "x": 3334,
+      "y": -219,
+      "name": "15. Bulk add words bottomsheet in playback screen",
       "clip": true,
-      "width": 402,
-      "height": 874,
-      "fill": "$bg-card",
+      "width": 393,
+      "height": 852,
+      "fill": "$bg-primary",
       "layout": "vertical",
       "children": [
         {
           "type": "frame",
-          "id": "zLNpX",
-          "name": "Status Bar",
+          "id": "R1eoH",
+          "name": "header",
           "width": "fill_container",
-          "height": 62,
           "padding": [
-            20,
-            24,
-            0,
-            24
+            16,
+            20
           ],
           "justifyContent": "space_between",
           "alignItems": "center",
           "children": [
             {
               "type": "text",
-              "id": "UQdAt",
-              "name": "timeLabel",
+              "id": "TXrCY",
               "fill": "$text-primary",
-              "content": "9:41",
+              "content": "전체 단어",
               "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
+              "fontSize": 20,
+              "fontWeight": "700"
             },
             {
               "type": "frame",
-              "id": "eyQnM",
-              "name": "iconsR",
-              "gap": 6,
-              "alignItems": "center",
+              "id": "v8urj",
+              "name": "closeBtn",
+              "width": 36,
+              "height": 36,
+              "fill": "$bg-card",
+              "cornerRadius": 18,
+              "layout": "none",
               "children": [
                 {
                   "type": "icon_font",
-                  "id": "TkHW0",
-                  "name": "sigIco",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "signal",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-primary"
-                },
-                {
-                  "type": "icon_font",
-                  "id": "ylWld",
-                  "name": "wifiIco",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "wifi",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-primary"
-                },
-                {
-                  "type": "icon_font",
-                  "id": "vrJNm",
-                  "name": "batIco",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "battery-full",
-                  "iconFontFamily": "lucide",
+                  "id": "v5NjA",
+                  "x": 7,
+                  "y": 7,
+                  "width": 22,
+                  "height": 22,
+                  "iconFontName": "x",
+                  "iconFontFamily": "feather",
                   "fill": "$text-primary"
                 }
               ]
@@ -22676,77 +22883,308 @@
         },
         {
           "type": "frame",
-          "id": "GQcaA",
-          "name": "Content Wrapper",
+          "id": "ukFrF",
+          "name": "filterRow",
           "width": "fill_container",
-          "height": "fill_container",
-          "layout": "vertical",
-          "gap": 12,
+          "gap": 8,
           "padding": [
-            8,
-            12,
-            24,
-            12
+            0,
+            20
           ],
           "children": [
             {
               "type": "frame",
-              "id": "KWLG7",
-              "name": "Profile Card",
+              "id": "YfM9S",
+              "fill": "#3B82F620",
+              "cornerRadius": 20,
+              "padding": [
+                8,
+                14
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "tBHfy",
+                  "fill": "#3B82F6",
+                  "content": "명사",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yxkr5",
+              "fill": "#10B98120",
+              "cornerRadius": 20,
+              "padding": [
+                8,
+                14
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "7YFua",
+                  "fill": "#10B981",
+                  "content": "동사",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "j6MI1",
+              "fill": "#F59E0B20",
+              "cornerRadius": 20,
+              "padding": [
+                8,
+                14
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "n6Xoh",
+                  "fill": "#F59E0B",
+                  "content": "형용사",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "GQXIR",
+              "fill": "#F59E0B20",
+              "cornerRadius": 20,
+              "padding": [
+                8,
+                14
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "gJfG5",
+                  "fill": "#F59E0B",
+                  "content": "형용동사",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "xe19l",
+              "fill": "#A855F720",
+              "cornerRadius": 20,
+              "padding": [
+                8,
+                14
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "4ksp4",
+                  "fill": "#A855F7",
+                  "content": "부사",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "QgtnD",
+              "fill": "$bg-card",
+              "cornerRadius": 20,
+              "padding": [
+                8,
+                14
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "4PJB0",
+                  "fill": "$text-secondary",
+                  "content": "대명사",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "8x3aI",
+              "fill": "$bg-card",
+              "cornerRadius": 20,
+              "padding": [
+                8,
+                14
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "f4ras",
+                  "fill": "$text-secondary",
+                  "content": "조동사",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "e7fjA",
+          "name": "selBar",
+          "width": "fill_container",
+          "gap": 12,
+          "padding": [
+            12,
+            20
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "80Blm",
+              "name": "cbAll",
+              "width": 24,
+              "height": 24,
+              "fill": "$accent-primary",
+              "cornerRadius": 6,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "OBUZQ",
+                  "layoutPosition": "absolute",
+                  "x": 5,
+                  "y": 5,
+                  "name": "chkIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "check",
+                  "iconFontFamily": "feather",
+                  "fill": "#FFFFFF"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "CECto",
+              "name": "countTxt",
+              "fill": "$text-secondary",
+              "content": "42개 단어",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "MGxcf",
+          "name": "wordList",
+          "clip": true,
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "padding": [
+            0,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "HVoa2",
+              "name": "row1",
               "width": "fill_container",
-              "fill": "$bg-primary",
-              "cornerRadius": 24,
-              "gap": 16,
-              "padding": 20,
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 0.5
+                },
+                "fill": "$border-default"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                0
+              ],
               "alignItems": "center",
               "children": [
                 {
                   "type": "frame",
-                  "id": "KNcbO",
-                  "name": "Avatar",
-                  "width": 56,
-                  "height": 56,
-                  "fill": "$bg-elevated",
-                  "cornerRadius": 24,
-                  "justifyContent": "center",
-                  "alignItems": "center",
+                  "id": "NSwlg",
+                  "name": "cb1",
+                  "width": 24,
+                  "height": 24,
+                  "fill": "$accent-primary",
+                  "cornerRadius": 6,
                   "children": [
                     {
                       "type": "icon_font",
-                      "id": "5TzHv",
-                      "name": "avatarIco",
-                      "width": 28,
-                      "height": 28,
-                      "iconFontName": "user",
-                      "iconFontFamily": "lucide",
-                      "fill": "$text-secondary"
+                      "id": "LzQIN",
+                      "layoutPosition": "absolute",
+                      "x": 5,
+                      "y": 5,
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "check",
+                      "iconFontFamily": "feather",
+                      "fill": "#FFFFFF"
                     }
                   ]
                 },
                 {
                   "type": "frame",
-                  "id": "FY4MT",
-                  "name": "profileInfo",
+                  "id": "eoJsS",
+                  "name": "info1",
                   "width": "fill_container",
                   "layout": "vertical",
-                  "gap": 4,
+                  "gap": 2,
                   "children": [
                     {
-                      "type": "text",
-                      "id": "JOsXD",
-                      "name": "profileName",
-                      "fill": "$text-primary",
-                      "content": "김동빛",
-                      "fontFamily": "Plus Jakarta Sans",
-                      "fontSize": 18,
-                      "fontWeight": "700"
+                      "type": "frame",
+                      "id": "IHOK3",
+                      "name": "texts1",
+                      "gap": 6,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "5Gdtu",
+                          "fill": "$text-primary",
+                          "content": "食べる",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "FmBLR",
+                          "fill": "$text-secondary",
+                          "content": "たべる",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
                     },
                     {
                       "type": "text",
-                      "id": "HCtLt",
-                      "name": "profileEmail",
+                      "id": "YKsfd",
                       "fill": "$text-secondary",
-                      "content": "eastshine@example.com",
+                      "content": "먹다",
                       "fontFamily": "Inter",
                       "fontSize": 13,
                       "fontWeight": "normal"
@@ -22754,198 +23192,24 @@
                   ]
                 },
                 {
-                  "type": "icon_font",
-                  "id": "1cYl9",
-                  "name": "profileChev",
-                  "width": 20,
-                  "height": 20,
-                  "iconFontName": "chevron-right",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-muted"
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "55UMz",
-              "name": "Settings Section",
-              "width": "fill_container",
-              "fill": "#FFFFFF00",
-              "layout": "vertical",
-              "gap": 12,
-              "children": [
-                {
-                  "type": "text",
-                  "id": "MaQcp",
-                  "name": "settingsLabel",
-                  "fill": "$text-secondary",
-                  "content": "설정",
-                  "fontFamily": "Inter",
-                  "fontSize": 13,
-                  "fontWeight": "600"
-                },
-                {
                   "type": "frame",
-                  "id": "NnA0D",
-                  "name": "Settings List",
-                  "clip": true,
-                  "width": "fill_container",
-                  "fill": "$bg-primary",
-                  "cornerRadius": 24,
-                  "layout": "vertical",
+                  "id": "0ynxc",
+                  "name": "badge1",
+                  "fill": "#10B98120",
+                  "cornerRadius": 10,
+                  "padding": [
+                    3,
+                    8
+                  ],
                   "children": [
                     {
-                      "type": "frame",
-                      "id": "BKyxX",
-                      "name": "catItem1-Review",
-                      "width": "fill_container",
-                      "gap": 12,
-                      "padding": [
-                        16,
-                        20
-                      ],
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "icon_font",
-                          "id": "MVuZV",
-                          "name": "ico1",
-                          "width": 18,
-                          "height": 18,
-                          "iconFontName": "brain",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-secondary"
-                        },
-                        {
-                          "type": "text",
-                          "id": "kjADY",
-                          "name": "txt1",
-                          "fill": "$text-primary",
-                          "content": "암기",
-                          "fontFamily": "Inter",
-                          "fontSize": 15,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "frame",
-                          "id": "ejQTu",
-                          "name": "spc1",
-                          "width": "fill_container",
-                          "height": 1
-                        },
-                        {
-                          "type": "icon_font",
-                          "id": "WzKQS",
-                          "name": "chv1",
-                          "width": 16,
-                          "height": 16,
-                          "iconFontName": "chevron-right",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-muted"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "EB2UA",
-                      "name": "catItem2-Playback",
-                      "width": "fill_container",
-                      "gap": 12,
-                      "padding": [
-                        16,
-                        20
-                      ],
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "icon_font",
-                          "id": "1koxa",
-                          "name": "ico2",
-                          "width": 18,
-                          "height": 18,
-                          "iconFontName": "music",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-secondary"
-                        },
-                        {
-                          "type": "text",
-                          "id": "is7Uy",
-                          "name": "txt2",
-                          "fill": "$text-primary",
-                          "content": "가사 재생",
-                          "fontFamily": "Inter",
-                          "fontSize": 15,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "frame",
-                          "id": "Ujf4y",
-                          "name": "spc2",
-                          "width": "fill_container",
-                          "height": 1
-                        },
-                        {
-                          "type": "icon_font",
-                          "id": "BPkr9",
-                          "name": "chv2",
-                          "width": 16,
-                          "height": 16,
-                          "iconFontName": "chevron-right",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-muted"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "Kzfb2",
-                      "name": "catItem3-Display",
-                      "width": "fill_container",
-                      "gap": 12,
-                      "padding": [
-                        16,
-                        20
-                      ],
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "icon_font",
-                          "id": "KksIw",
-                          "name": "ico3",
-                          "width": 18,
-                          "height": 18,
-                          "iconFontName": "type",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-secondary"
-                        },
-                        {
-                          "type": "text",
-                          "id": "AsI67",
-                          "name": "txt3",
-                          "fill": "$text-primary",
-                          "content": "표시",
-                          "fontFamily": "Inter",
-                          "fontSize": 15,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "frame",
-                          "id": "LZk2k",
-                          "name": "spc3",
-                          "width": "fill_container",
-                          "height": 1
-                        },
-                        {
-                          "type": "icon_font",
-                          "id": "6c5QV",
-                          "name": "chv3",
-                          "width": 16,
-                          "height": 16,
-                          "iconFontName": "chevron-right",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-muted"
-                        }
-                      ]
+                      "type": "text",
+                      "id": "Xz6mj",
+                      "fill": "#10B981",
+                      "content": "동사",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "600"
                     }
                   ]
                 }
@@ -22953,1315 +23217,493 @@
             },
             {
               "type": "frame",
-              "id": "UUq1w",
-              "name": "Account Section",
+              "id": "lYnTd",
+              "name": "row2",
               "width": "fill_container",
-              "fill": "#FFFFFF00",
-              "layout": "vertical",
-              "gap": 12,
-              "children": [
-                {
-                  "type": "text",
-                  "id": "kGine",
-                  "name": "accountLabel",
-                  "fill": "$text-secondary",
-                  "content": "계정 관리",
-                  "fontFamily": "Inter",
-                  "fontSize": 13,
-                  "fontWeight": "600"
-                },
-                {
-                  "type": "frame",
-                  "id": "O9qPB",
-                  "name": "Account List",
-                  "clip": true,
-                  "width": "fill_container",
-                  "fill": "$bg-primary",
-                  "cornerRadius": 24,
-                  "layout": "vertical",
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "kv2b5",
-                      "name": "accItem1",
-                      "width": "fill_container",
-                      "gap": 12,
-                      "padding": [
-                        16,
-                        20
-                      ],
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "icon_font",
-                          "id": "HxZG5",
-                          "name": "accIco1",
-                          "width": 18,
-                          "height": 18,
-                          "iconFontName": "user-pen",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-secondary"
-                        },
-                        {
-                          "type": "text",
-                          "id": "tTIme",
-                          "name": "accTxt1",
-                          "fill": "$text-primary",
-                          "content": "프로필 수정",
-                          "fontFamily": "Inter",
-                          "fontSize": 15,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "frame",
-                          "id": "4jxai",
-                          "name": "accSpacer1",
-                          "width": "fill_container",
-                          "height": 1
-                        },
-                        {
-                          "type": "icon_font",
-                          "id": "cwCNA",
-                          "name": "accChev1",
-                          "width": 16,
-                          "height": 16,
-                          "iconFontName": "chevron-right",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-muted"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "rectangle",
-                      "id": "jOld9",
-                      "x": 0,
-                      "y": 54,
-                      "name": "accDiv1",
-                      "enabled": false,
-                      "fill": "$border-default",
-                      "width": "fill_container(362)",
-                      "height": 1
-                    },
-                    {
-                      "type": "frame",
-                      "id": "s49wL",
-                      "name": "accItem2",
-                      "width": "fill_container",
-                      "gap": 12,
-                      "padding": [
-                        16,
-                        20
-                      ],
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "icon_font",
-                          "id": "PcWqG",
-                          "name": "accIco2",
-                          "width": 18,
-                          "height": 18,
-                          "iconFontName": "lock",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-secondary"
-                        },
-                        {
-                          "type": "text",
-                          "id": "Uadgr",
-                          "name": "accTxt2",
-                          "fill": "$text-primary",
-                          "content": "비밀번호 변경",
-                          "fontFamily": "Inter",
-                          "fontSize": 15,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "frame",
-                          "id": "pW88D",
-                          "name": "accSpacer2",
-                          "width": "fill_container",
-                          "height": 1
-                        },
-                        {
-                          "type": "icon_font",
-                          "id": "oi0lU",
-                          "name": "accChev2",
-                          "width": 16,
-                          "height": 16,
-                          "iconFontName": "chevron-right",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-muted"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "e0Xoh",
-              "name": "logoutBtn",
-              "fill": "$text-muted",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "로그아웃",
-              "textAlign": "center",
-              "fontFamily": "Inter",
-              "fontSize": 14,
-              "fontWeight": "500"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "4lGcj",
-          "name": "Tab Bar Container",
-          "width": "fill_container",
-          "padding": [
-            12,
-            21,
-            21,
-            21
-          ],
-          "justifyContent": "center",
-          "children": [
-            {
-              "type": "frame",
-              "id": "PV7Wk",
-              "name": "Pill",
-              "width": "fill_container",
-              "height": 62,
-              "fill": "$bg-primary",
-              "cornerRadius": 100,
               "stroke": {
-                "thickness": 0
-              },
-              "effect": {
-                "type": "shadow",
-                "shadowType": "outer",
-                "color": "#00000012",
-                "offset": {
-                  "x": 0,
-                  "y": 2
+                "align": "inside",
+                "thickness": {
+                  "bottom": 0.5
                 },
-                "blur": 8
+                "fill": "$border-default"
               },
-              "padding": 4,
+              "gap": 12,
+              "padding": [
+                12,
+                0
+              ],
               "alignItems": "center",
               "children": [
                 {
                   "type": "frame",
-                  "id": "SSxVK",
-                  "name": "Home Tab",
-                  "width": "fill_container",
-                  "height": "fill_container",
-                  "cornerRadius": 26,
-                  "layout": "vertical",
-                  "gap": 4,
-                  "justifyContent": "center",
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "icon_font",
-                      "id": "V7F2p",
-                      "name": "tab1Ico",
-                      "width": 18,
-                      "height": 18,
-                      "iconFontName": "house",
-                      "iconFontFamily": "lucide",
-                      "fill": "$text-muted"
-                    },
-                    {
-                      "type": "text",
-                      "id": "jhq4A",
-                      "name": "tab1Lbl",
-                      "fill": "$text-muted",
-                      "content": "HOME",
-                      "fontFamily": "Inter",
-                      "fontSize": 10,
-                      "fontWeight": "500",
-                      "letterSpacing": 0.5
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "5iBAW",
-                  "name": "Words Tab",
-                  "width": "fill_container",
-                  "height": "fill_container",
-                  "cornerRadius": 26,
-                  "layout": "vertical",
-                  "gap": 4,
-                  "justifyContent": "center",
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "icon_font",
-                      "id": "ZXbyQ",
-                      "name": "tab2Ico",
-                      "width": 18,
-                      "height": 18,
-                      "iconFontName": "book-open",
-                      "iconFontFamily": "lucide",
-                      "fill": "$text-muted"
-                    },
-                    {
-                      "type": "text",
-                      "id": "gLOt8",
-                      "name": "tab2Lbl",
-                      "fill": "$text-muted",
-                      "content": "WORDS",
-                      "fontFamily": "Inter",
-                      "fontSize": 10,
-                      "fontWeight": "500",
-                      "letterSpacing": 0.5
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "Ob4uM",
-                  "name": "My Tab - Active",
-                  "width": "fill_container",
-                  "height": "fill_container",
+                  "id": "Zaj8n",
+                  "name": "cb2",
+                  "width": 24,
+                  "height": 24,
                   "fill": "$accent-primary",
-                  "cornerRadius": 26,
-                  "layout": "vertical",
-                  "gap": 4,
-                  "justifyContent": "center",
-                  "alignItems": "center",
+                  "cornerRadius": 6,
                   "children": [
                     {
                       "type": "icon_font",
-                      "id": "KnVeH",
-                      "name": "tab3Ico",
-                      "width": 18,
-                      "height": 18,
-                      "iconFontName": "user",
-                      "iconFontFamily": "lucide",
+                      "id": "FUiQl",
+                      "layoutPosition": "absolute",
+                      "x": 5,
+                      "y": 5,
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "check",
+                      "iconFontFamily": "feather",
                       "fill": "#FFFFFF"
-                    },
-                    {
-                      "type": "text",
-                      "id": "i8uq2",
-                      "name": "tab3Lbl",
-                      "fill": "#FFFFFF",
-                      "content": "MY",
-                      "fontFamily": "Inter",
-                      "fontSize": 10,
-                      "fontWeight": "600",
-                      "letterSpacing": 0.5
                     }
                   ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "frame",
-      "id": "6YzPl",
-      "x": 861,
-      "y": 6020,
-      "name": "7b. Settings - 암기",
-      "clip": true,
-      "width": 402,
-      "height": 874,
-      "fill": "$bg-card",
-      "layout": "vertical",
-      "children": [
-        {
-          "type": "frame",
-          "id": "ZMRZ1",
-          "name": "Status Bar",
-          "width": "fill_container",
-          "height": 62,
-          "padding": [
-            20,
-            24,
-            0,
-            24
-          ],
-          "justifyContent": "space_between",
-          "alignItems": "center",
-          "children": [
-            {
-              "type": "text",
-              "id": "zCUMK",
-              "name": "timeL",
-              "fill": "$text-primary",
-              "content": "9:41",
-              "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
-            },
-            {
-              "type": "frame",
-              "id": "0I7fQ",
-              "name": "iconsR",
-              "gap": 6,
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "icon_font",
-                  "id": "HfhV9",
-                  "name": "sig",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "signal",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-primary"
                 },
-                {
-                  "type": "icon_font",
-                  "id": "edqXl",
-                  "name": "wifi",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "wifi",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-primary"
-                },
-                {
-                  "type": "icon_font",
-                  "id": "KQzQk",
-                  "name": "bat",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "battery-full",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-primary"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "qMAwk",
-          "name": "Header",
-          "width": "fill_container",
-          "height": 48,
-          "gap": 12,
-          "padding": [
-            0,
-            16
-          ],
-          "alignItems": "center",
-          "children": [
-            {
-              "type": "icon_font",
-              "id": "YhabI",
-              "name": "backIco",
-              "width": 24,
-              "height": 24,
-              "iconFontName": "chevron-left",
-              "iconFontFamily": "lucide",
-              "fill": "$text-primary"
-            },
-            {
-              "type": "text",
-              "id": "Xv3Dq",
-              "name": "headerTitle",
-              "fill": "$text-primary",
-              "content": "암기",
-              "fontFamily": "Inter",
-              "fontSize": 17,
-              "fontWeight": "600"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "WEcdD",
-          "name": "Content Wrapper",
-          "width": "fill_container",
-          "height": "fill_container",
-          "layout": "vertical",
-          "gap": 24,
-          "padding": [
-            16,
-            12,
-            24,
-            12
-          ],
-          "children": [
-            {
-              "type": "frame",
-              "id": "evOIh",
-              "name": "Settings Card",
-              "clip": true,
-              "width": "fill_container",
-              "fill": "$bg-primary",
-              "cornerRadius": 24,
-              "layout": "vertical",
-              "children": [
                 {
                   "type": "frame",
-                  "id": "pyRTm",
-                  "name": "Retention Setting",
+                  "id": "Rm2nz",
+                  "name": "info2",
                   "width": "fill_container",
                   "layout": "vertical",
-                  "gap": 8,
-                  "padding": [
-                    16,
-                    20
-                  ],
+                  "gap": 2,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "DkYgz",
-                      "name": "retHeader",
-                      "width": "fill_container",
-                      "alignItems": "center",
+                      "id": "9OGn3",
+                      "name": "texts2",
+                      "gap": 6,
+                      "alignItems": "end",
                       "children": [
                         {
-                          "type": "icon_font",
-                          "id": "H8I4R",
-                          "name": "retIco",
-                          "width": 18,
-                          "height": 18,
-                          "iconFontName": "target",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-secondary"
-                        },
-                        {
                           "type": "text",
-                          "id": "Vb61W",
-                          "name": "retLabel",
+                          "id": "5oU7n",
                           "fill": "$text-primary",
-                          "content": "목표 기억률",
+                          "content": "世界",
                           "fontFamily": "Inter",
-                          "fontSize": 15,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "frame",
-                          "id": "LocRF",
-                          "name": "retSpacer",
-                          "width": "fill_container",
-                          "height": 1
+                          "fontSize": 16,
+                          "fontWeight": "700"
                         },
                         {
                           "type": "text",
-                          "id": "UTcGr",
-                          "name": "retVal",
-                          "fill": "$accent-primary",
-                          "content": "0.90",
-                          "fontFamily": "Plus Jakarta Sans",
-                          "fontSize": 15,
-                          "fontWeight": "800"
+                          "id": "6N3zy",
+                          "fill": "$text-secondary",
+                          "content": "せかい",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
                         }
                       ]
                     },
                     {
                       "type": "text",
-                      "id": "UTrAT",
-                      "name": "retDesc",
-                      "fill": "$text-muted",
-                      "textGrowth": "fixed-width",
-                      "width": "fill_container",
-                      "content": "FSRS 알고리즘의 목표 기억 유지율입니다. 높을수록 복습 주기가 짧아집니다.",
+                      "id": "OZgMS",
+                      "fill": "$text-secondary",
+                      "content": "세계",
                       "fontFamily": "Inter",
-                      "fontSize": 12,
+                      "fontSize": 13,
                       "fontWeight": "normal"
-                    },
-                    {
-                      "type": "frame",
-                      "id": "CwJ69",
-                      "name": "Slider",
-                      "width": "fill_container",
-                      "height": 28,
-                      "layout": "none",
-                      "children": [
-                        {
-                          "type": "rectangle",
-                          "cornerRadius": 2,
-                          "id": "dXlyF",
-                          "x": 0,
-                          "y": 12,
-                          "name": "sliderBg",
-                          "fill": "$bg-elevated",
-                          "width": 322,
-                          "height": 4
-                        },
-                        {
-                          "type": "rectangle",
-                          "cornerRadius": 2,
-                          "id": "sRdqE",
-                          "x": 0,
-                          "y": 12,
-                          "name": "sliderFill",
-                          "fill": "$accent-primary",
-                          "width": 280,
-                          "height": 4
-                        },
-                        {
-                          "type": "ellipse",
-                          "id": "tVh9z",
-                          "x": 272,
-                          "y": 6,
-                          "name": "sliderThumb",
-                          "fill": "#FFFFFF",
-                          "width": 16,
-                          "height": 16,
-                          "effect": {
-                            "type": "shadow",
-                            "shadowType": "outer",
-                            "color": "#00000040",
-                            "offset": {
-                              "x": 0,
-                              "y": 2
-                            },
-                            "blur": 4
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "wi0fE",
-                      "name": "sliderLabels",
-                      "width": "fill_container",
-                      "justifyContent": "space_between",
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "Pxr1E",
-                          "name": "slMin",
-                          "fill": "$text-muted",
-                          "content": "0.70",
-                          "fontFamily": "Inter",
-                          "fontSize": 10,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "text",
-                          "id": "LRqE0",
-                          "name": "slMax",
-                          "fill": "$text-muted",
-                          "content": "0.99",
-                          "fontFamily": "Inter",
-                          "fontSize": 10,
-                          "fontWeight": "500"
-                        }
-                      ]
                     }
                   ]
                 },
                 {
-                  "type": "rectangle",
-                  "id": "Tkd6N",
-                  "name": "divider",
-                  "fill": "$bg-elevated",
-                  "width": "fill_container",
-                  "height": 1
-                },
-                {
                   "type": "frame",
-                  "id": "Hcok1",
-                  "name": "Interval Setting",
-                  "width": "fill_container",
-                  "gap": 12,
+                  "id": "8yPDG",
+                  "name": "badge2",
+                  "fill": "#3B82F620",
+                  "cornerRadius": 10,
                   "padding": [
-                    16,
-                    20
+                    3,
+                    8
                   ],
-                  "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
-                      "id": "ZTYrD",
-                      "name": "intIco",
-                      "width": 18,
-                      "height": 18,
-                      "iconFontName": "timer",
-                      "iconFontFamily": "lucide",
-                      "fill": "$text-secondary"
-                    },
-                    {
-                      "type": "frame",
-                      "id": "5r7Ny",
-                      "name": "intTextWrap",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 4,
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "Ma0bk",
-                          "name": "intLabel",
-                          "fill": "$text-primary",
-                          "content": "다음 복습 시점 노출",
-                          "fontFamily": "Inter",
-                          "fontSize": 15,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "text",
-                          "id": "YdAp6",
-                          "name": "intDesc",
-                          "fill": "$text-muted",
-                          "textGrowth": "fixed-width",
-                          "width": "fill_container",
-                          "content": "플래시카드 선택지에 다음 복습 예정일을 표시합니다",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "Q8ioZ",
-                      "name": "Toggle",
-                      "width": 48,
-                      "height": 28,
-                      "fill": "$accent-green",
-                      "cornerRadius": 20,
-                      "layout": "none",
-                      "children": [
-                        {
-                          "type": "ellipse",
-                          "id": "gXBm1",
-                          "x": 22,
-                          "y": 2,
-                          "name": "knob",
-                          "fill": "#FFFFFF",
-                          "width": 24,
-                          "height": 24,
-                          "effect": {
-                            "type": "shadow",
-                            "shadowType": "outer",
-                            "color": "#00000030",
-                            "offset": {
-                              "x": 0,
-                              "y": 1
-                            },
-                            "blur": 3
-                          }
-                        }
-                      ]
+                      "type": "text",
+                      "id": "30rIY",
+                      "fill": "#3B82F6",
+                      "content": "명사",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "600"
                     }
                   ]
                 }
               ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "frame",
-      "id": "Zfds4",
-      "x": 1323,
-      "y": 6020,
-      "name": "7c. Settings - 가사 재생",
-      "clip": true,
-      "width": 402,
-      "height": 874,
-      "fill": "$bg-card",
-      "layout": "vertical",
-      "children": [
-        {
-          "type": "frame",
-          "id": "UmXla",
-          "name": "Status Bar",
-          "width": "fill_container",
-          "height": 62,
-          "padding": [
-            20,
-            24,
-            0,
-            24
-          ],
-          "justifyContent": "space_between",
-          "alignItems": "center",
-          "children": [
-            {
-              "type": "text",
-              "id": "00Oll",
-              "name": "tm",
-              "fill": "$text-primary",
-              "content": "9:41",
-              "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
             },
             {
               "type": "frame",
-              "id": "pEnfe",
-              "name": "iconsR",
-              "gap": 6,
+              "id": "n8yQG",
+              "name": "row3",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 0.5
+                },
+                "fill": "$border-default"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                0
+              ],
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
-                  "id": "BjNBI",
-                  "name": "s1",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "signal",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-primary"
-                },
-                {
-                  "type": "icon_font",
-                  "id": "ARhpw",
-                  "name": "w1",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "wifi",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-primary"
-                },
-                {
-                  "type": "icon_font",
-                  "id": "t1hpq",
-                  "name": "b1",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "battery-full",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-primary"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "s0gMT",
-          "name": "Header",
-          "width": "fill_container",
-          "height": 48,
-          "gap": 12,
-          "padding": [
-            0,
-            16
-          ],
-          "alignItems": "center",
-          "children": [
-            {
-              "type": "icon_font",
-              "id": "WVtDM",
-              "name": "bk",
-              "width": 24,
-              "height": 24,
-              "iconFontName": "chevron-left",
-              "iconFontFamily": "lucide",
-              "fill": "$text-primary"
-            },
-            {
-              "type": "text",
-              "id": "Sc5F0",
-              "name": "ht",
-              "fill": "$text-primary",
-              "content": "가사 재생",
-              "fontFamily": "Inter",
-              "fontSize": 17,
-              "fontWeight": "600"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "XbkI8",
-          "name": "Content Wrapper",
-          "width": "fill_container",
-          "height": "fill_container",
-          "layout": "vertical",
-          "gap": 24,
-          "padding": [
-            16,
-            12,
-            24,
-            12
-          ],
-          "children": [
-            {
-              "type": "frame",
-              "id": "PTteO",
-              "name": "Settings Card",
-              "clip": true,
-              "width": "fill_container",
-              "fill": "$bg-primary",
-              "cornerRadius": 24,
-              "layout": "vertical",
-              "children": [
-                {
                   "type": "frame",
-                  "id": "o1qN6",
-                  "name": "Furigana Setting",
-                  "width": "fill_container",
-                  "gap": 12,
-                  "padding": [
-                    16,
-                    20
-                  ],
-                  "alignItems": "center",
+                  "id": "2HlEl",
+                  "name": "cb3",
+                  "width": 24,
+                  "height": 24,
+                  "fill": "$accent-primary",
+                  "cornerRadius": 6,
                   "children": [
                     {
                       "type": "icon_font",
-                      "id": "kH0rR",
-                      "name": "i1",
-                      "width": 18,
-                      "height": 18,
-                      "iconFontName": "languages",
-                      "iconFontFamily": "lucide",
-                      "fill": "$text-secondary"
-                    },
-                    {
-                      "type": "frame",
-                      "id": "xwIc0",
-                      "name": "furiTextWrap",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 4,
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "h23zQ",
-                          "name": "l1",
-                          "fill": "$text-primary",
-                          "content": "후리가나 표시",
-                          "fontFamily": "Inter",
-                          "fontSize": 15,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "text",
-                          "id": "axI6Q",
-                          "name": "d1",
-                          "fill": "$text-muted",
-                          "textGrowth": "fixed-width",
-                          "width": "fill_container",
-                          "content": "재생 화면에서 한자 위에 히라가나 읽기를 표시합니다",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "Guim1",
-                      "name": "Toggle",
-                      "width": 48,
-                      "height": 28,
-                      "fill": "$accent-green",
-                      "cornerRadius": 20,
-                      "layout": "none",
-                      "children": [
-                        {
-                          "type": "ellipse",
-                          "id": "oOXzc",
-                          "x": 22,
-                          "y": 2,
-                          "name": "kn1",
-                          "fill": "#FFFFFF",
-                          "width": 24,
-                          "height": 24,
-                          "effect": {
-                            "type": "shadow",
-                            "shadowType": "outer",
-                            "color": "#00000030",
-                            "offset": {
-                              "x": 0,
-                              "y": 1
-                            },
-                            "blur": 3
-                          }
-                        }
-                      ]
+                      "id": "wLHTo",
+                      "layoutPosition": "absolute",
+                      "x": 5,
+                      "y": 5,
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "check",
+                      "iconFontFamily": "feather",
+                      "fill": "#FFFFFF"
                     }
                   ]
                 },
                 {
-                  "type": "rectangle",
-                  "id": "TPhHU",
-                  "name": "divider",
-                  "fill": "$bg-elevated",
-                  "width": "fill_container",
-                  "height": 1
-                },
-                {
                   "type": "frame",
-                  "id": "GPE9K",
-                  "name": "Korean Pronunciation Setting",
-                  "width": "fill_container",
-                  "gap": 12,
-                  "padding": [
-                    16,
-                    20
-                  ],
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "icon_font",
-                      "id": "KV44S",
-                      "name": "i2",
-                      "width": 18,
-                      "height": 18,
-                      "iconFontName": "speech",
-                      "iconFontFamily": "lucide",
-                      "fill": "$text-secondary"
-                    },
-                    {
-                      "type": "frame",
-                      "id": "TRYG5",
-                      "name": "korTextWrap",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 4,
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "cpdUL",
-                          "name": "l2",
-                          "fill": "$text-primary",
-                          "content": "한국어 발음 표시",
-                          "fontFamily": "Inter",
-                          "fontSize": 15,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "text",
-                          "id": "mLuON",
-                          "name": "d2",
-                          "fill": "$text-muted",
-                          "textGrowth": "fixed-width",
-                          "width": "fill_container",
-                          "content": "재생 화면에서 가사의 한국어 발음을 표시합니다",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "7SF5Y",
-                      "name": "Toggle",
-                      "width": 48,
-                      "height": 28,
-                      "fill": "$accent-green",
-                      "cornerRadius": 20,
-                      "layout": "none",
-                      "children": [
-                        {
-                          "type": "ellipse",
-                          "id": "vCVZp",
-                          "x": 22,
-                          "y": 2,
-                          "name": "kn2",
-                          "fill": "#FFFFFF",
-                          "width": 24,
-                          "height": 24,
-                          "effect": {
-                            "type": "shadow",
-                            "shadowType": "outer",
-                            "color": "#00000030",
-                            "offset": {
-                              "x": 0,
-                              "y": 1
-                            },
-                            "blur": 3
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "frame",
-      "id": "HwdE5",
-      "x": 1785,
-      "y": 6020,
-      "name": "7d. Settings - 표시",
-      "clip": true,
-      "width": 402,
-      "height": 874,
-      "fill": "$bg-card",
-      "layout": "vertical",
-      "children": [
-        {
-          "type": "frame",
-          "id": "7gT4Z",
-          "name": "Status Bar",
-          "width": "fill_container",
-          "height": 62,
-          "padding": [
-            20,
-            24,
-            0,
-            24
-          ],
-          "justifyContent": "space_between",
-          "alignItems": "center",
-          "children": [
-            {
-              "type": "text",
-              "id": "8SnWE",
-              "name": "tm",
-              "fill": "$text-primary",
-              "content": "9:41",
-              "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
-            },
-            {
-              "type": "frame",
-              "id": "2YRfv",
-              "name": "iconsR",
-              "gap": 6,
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "icon_font",
-                  "id": "4gBfK",
-                  "name": "s1",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "signal",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-primary"
-                },
-                {
-                  "type": "icon_font",
-                  "id": "BE6Ho",
-                  "name": "w1",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "wifi",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-primary"
-                },
-                {
-                  "type": "icon_font",
-                  "id": "dh4K8",
-                  "name": "b1",
-                  "width": 16,
-                  "height": 16,
-                  "iconFontName": "battery-full",
-                  "iconFontFamily": "lucide",
-                  "fill": "$text-primary"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "8cJyJ",
-          "name": "Header",
-          "width": "fill_container",
-          "height": 48,
-          "gap": 12,
-          "padding": [
-            0,
-            16
-          ],
-          "alignItems": "center",
-          "children": [
-            {
-              "type": "icon_font",
-              "id": "0NLb4",
-              "name": "bk",
-              "width": 24,
-              "height": 24,
-              "iconFontName": "chevron-left",
-              "iconFontFamily": "lucide",
-              "fill": "$text-primary"
-            },
-            {
-              "type": "text",
-              "id": "5M0Pt",
-              "name": "ht",
-              "fill": "$text-primary",
-              "content": "표시",
-              "fontFamily": "Inter",
-              "fontSize": 17,
-              "fontWeight": "600"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "M2Zu0",
-          "name": "Content Wrapper",
-          "width": "fill_container",
-          "height": "fill_container",
-          "layout": "vertical",
-          "gap": 24,
-          "padding": [
-            16,
-            12,
-            24,
-            12
-          ],
-          "children": [
-            {
-              "type": "frame",
-              "id": "jro4Q",
-              "name": "Settings Card",
-              "clip": true,
-              "width": "fill_container",
-              "fill": "$bg-primary",
-              "cornerRadius": 24,
-              "layout": "vertical",
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "eTrK2",
-                  "name": "Reading Display Setting",
+                  "id": "bhgwf",
+                  "name": "info3",
                   "width": "fill_container",
                   "layout": "vertical",
-                  "gap": 12,
-                  "padding": [
-                    16,
-                    20
-                  ],
+                  "gap": 2,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "zoxM3",
-                      "name": "rdHeader",
-                      "width": "fill_container",
-                      "gap": 8,
-                      "alignItems": "center",
+                      "id": "zULGp",
+                      "name": "texts3",
+                      "gap": 6,
+                      "alignItems": "end",
                       "children": [
                         {
-                          "type": "icon_font",
-                          "id": "nAmf9",
-                          "name": "rdIco",
-                          "width": 18,
-                          "height": 18,
-                          "iconFontName": "type",
-                          "iconFontFamily": "lucide",
-                          "fill": "$text-secondary"
+                          "type": "text",
+                          "id": "d6LYq",
+                          "fill": "$text-primary",
+                          "content": "美しい",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "700"
                         },
                         {
                           "type": "text",
-                          "id": "JkjmE",
-                          "name": "rdLabel",
-                          "fill": "$text-primary",
-                          "content": "읽기 표기 방식",
+                          "id": "2rZ9J",
+                          "fill": "$text-secondary",
+                          "content": "うつくしい",
                           "fontFamily": "Inter",
-                          "fontSize": 15,
-                          "fontWeight": "500"
+                          "fontSize": 12,
+                          "fontWeight": "normal"
                         }
                       ]
                     },
                     {
                       "type": "text",
-                      "id": "8Uyuz",
-                      "name": "rdDesc",
-                      "fill": "$text-muted",
-                      "textGrowth": "fixed-width",
-                      "width": "fill_container",
-                      "content": "단어의 읽기(발음)를 어떤 문자로 표시할지 선택합니다. 재생 화면과 복습 화면 모두에 적용됩니다.",
+                      "id": "spX4D",
+                      "fill": "$text-secondary",
+                      "content": "아름답다",
                       "fontFamily": "Inter",
-                      "fontSize": 12,
+                      "fontSize": 13,
                       "fontWeight": "normal"
-                    },
-                    {
-                      "type": "frame",
-                      "id": "1S26k",
-                      "name": "readingOptions",
-                      "width": "fill_container",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "type": "frame",
-                          "id": "5BWXD",
-                          "name": "opt-katakana",
-                          "width": "fill_container",
-                          "fill": "$accent-primary",
-                          "cornerRadius": 12,
-                          "padding": [
-                            10,
-                            0
-                          ],
-                          "justifyContent": "center",
-                          "alignItems": "center",
-                          "children": [
-                            {
-                              "type": "text",
-                              "id": "SdtP0",
-                              "name": "opt1t",
-                              "fill": "#FFFFFF",
-                              "content": "カタカナ",
-                              "fontFamily": "Inter",
-                              "fontSize": 14,
-                              "fontWeight": "500"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "frame",
-                          "id": "vqvZI",
-                          "name": "opt-hiragana",
-                          "width": "fill_container",
-                          "fill": "$bg-card",
-                          "cornerRadius": 12,
-                          "padding": [
-                            10,
-                            0
-                          ],
-                          "justifyContent": "center",
-                          "alignItems": "center",
-                          "children": [
-                            {
-                              "type": "text",
-                              "id": "PTks9",
-                              "name": "opt2t",
-                              "fill": "$text-secondary",
-                              "content": "ひらがな",
-                              "fontFamily": "Inter",
-                              "fontSize": 14,
-                              "fontWeight": "500"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "frame",
-                          "id": "UBOeA",
-                          "name": "opt-korean",
-                          "width": "fill_container",
-                          "fill": "$bg-card",
-                          "cornerRadius": 12,
-                          "padding": [
-                            10,
-                            0
-                          ],
-                          "justifyContent": "center",
-                          "alignItems": "center",
-                          "children": [
-                            {
-                              "type": "text",
-                              "id": "tMpyE",
-                              "name": "opt3t",
-                              "fill": "$text-secondary",
-                              "content": "한국어",
-                              "fontFamily": "Inter",
-                              "fontSize": 14,
-                              "fontWeight": "500"
-                            }
-                          ]
-                        }
-                      ]
                     }
                   ]
+                },
+                {
+                  "type": "frame",
+                  "id": "W9mLZ",
+                  "name": "badge3",
+                  "fill": "#F59E0B20",
+                  "cornerRadius": 10,
+                  "padding": [
+                    3,
+                    8
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "KHglA",
+                      "fill": "#F59E0B",
+                      "content": "형용사",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "hxbLN",
+              "name": "row4",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 0.5
+                },
+                "fill": "$border-default"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "SogBQ",
+                  "name": "cb4",
+                  "width": 24,
+                  "height": 24,
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "thickness": 2,
+                    "fill": "$border-default"
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "krloQ",
+                  "name": "info4",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "sX8iy",
+                      "name": "texts4",
+                      "gap": 6,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "iLfBK",
+                          "fill": "$text-primary",
+                          "content": "走る",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "mxVgu",
+                          "fill": "$text-secondary",
+                          "content": "はしる",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "GBAm5",
+                      "fill": "$text-secondary",
+                      "content": "달리다",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Qnvgj",
+                  "name": "badge4",
+                  "fill": "#10B98120",
+                  "cornerRadius": 10,
+                  "padding": [
+                    3,
+                    8
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "vwF9g",
+                      "fill": "#10B981",
+                      "content": "동사",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "MNkLk",
+              "name": "row5",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 0.5
+                },
+                "fill": "$border-default"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "WuR2p",
+                  "name": "cb5",
+                  "width": 24,
+                  "height": 24,
+                  "fill": "$accent-primary",
+                  "cornerRadius": 6,
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "v8SKu",
+                      "layoutPosition": "absolute",
+                      "x": 5,
+                      "y": 5,
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "check",
+                      "iconFontFamily": "feather",
+                      "fill": "#FFFFFF"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "UOCkT",
+                  "name": "info5",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "kiUOk",
+                      "name": "texts5",
+                      "gap": 6,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "RvbLu",
+                          "fill": "$text-primary",
+                          "content": "夢",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "PVRwH",
+                          "fill": "$text-secondary",
+                          "content": "ゆめ",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "hBSpp",
+                      "fill": "$text-secondary",
+                      "content": "꿈",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "y0Svl",
+                  "name": "badge5",
+                  "fill": "#3B82F620",
+                  "cornerRadius": 10,
+                  "padding": [
+                    3,
+                    8
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "6C6Qd",
+                      "fill": "#3B82F6",
+                      "content": "명사",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "s4K75",
+          "name": "ctaArea",
+          "width": "fill_container",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 0.5
+            },
+            "fill": "$border-default"
+          },
+          "layout": "vertical",
+          "padding": [
+            12,
+            20,
+            28,
+            20
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "KBxtB",
+              "name": "ctaBtn",
+              "width": "fill_container",
+              "height": 52,
+              "fill": "$accent-primary",
+              "cornerRadius": 26,
+              "gap": 8,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "Rd0kg",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "feather",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "text",
+                  "id": "EjZTB",
+                  "fill": "#FFFFFF",
+                  "content": "42개 단어 담기",
+                  "fontFamily": "Inter",
+                  "fontSize": 16,
+                  "fontWeight": "600"
                 }
               ]
             }

--- a/app-rn/japanese-vocabulary.pen
+++ b/app-rn/japanese-vocabulary.pen
@@ -22595,6 +22595,1679 @@
           ]
         }
       ]
+    },
+    {
+      "type": "frame",
+      "id": "sz5hR",
+      "x": 399,
+      "y": 6020,
+      "name": "7a. My Page Tab (Redesigned)",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "$bg-card",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "zLNpX",
+          "name": "Status Bar",
+          "width": "fill_container",
+          "height": 62,
+          "padding": [
+            20,
+            24,
+            0,
+            24
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "UQdAt",
+              "name": "timeLabel",
+              "fill": "$text-primary",
+              "content": "9:41",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "eyQnM",
+              "name": "iconsR",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "TkHW0",
+                  "name": "sigIco",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "signal",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "ylWld",
+                  "name": "wifiIco",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "wifi",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "vrJNm",
+                  "name": "batIco",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "battery-full",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "GQcaA",
+          "name": "Content Wrapper",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 12,
+          "padding": [
+            8,
+            12,
+            24,
+            12
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "KWLG7",
+              "name": "Profile Card",
+              "width": "fill_container",
+              "fill": "$bg-primary",
+              "cornerRadius": 24,
+              "gap": 16,
+              "padding": 20,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KNcbO",
+                  "name": "Avatar",
+                  "width": 56,
+                  "height": 56,
+                  "fill": "$bg-elevated",
+                  "cornerRadius": 24,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "5TzHv",
+                      "name": "avatarIco",
+                      "width": 28,
+                      "height": 28,
+                      "iconFontName": "user",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-secondary"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "FY4MT",
+                  "name": "profileInfo",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "JOsXD",
+                      "name": "profileName",
+                      "fill": "$text-primary",
+                      "content": "김동빛",
+                      "fontFamily": "Plus Jakarta Sans",
+                      "fontSize": 18,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "HCtLt",
+                      "name": "profileEmail",
+                      "fill": "$text-secondary",
+                      "content": "eastshine@example.com",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "icon_font",
+                  "id": "1cYl9",
+                  "name": "profileChev",
+                  "width": 20,
+                  "height": 20,
+                  "iconFontName": "chevron-right",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-muted"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "55UMz",
+              "name": "Settings Section",
+              "width": "fill_container",
+              "fill": "#FFFFFF00",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "MaQcp",
+                  "name": "settingsLabel",
+                  "fill": "$text-secondary",
+                  "content": "설정",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "frame",
+                  "id": "NnA0D",
+                  "name": "Settings List",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": "$bg-primary",
+                  "cornerRadius": 24,
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BKyxX",
+                      "name": "catItem1-Review",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "MVuZV",
+                          "name": "ico1",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "brain",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-secondary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "kjADY",
+                          "name": "txt1",
+                          "fill": "$text-primary",
+                          "content": "암기",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ejQTu",
+                          "name": "spc1",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "WzKQS",
+                          "name": "chv1",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "EB2UA",
+                      "name": "catItem2-Playback",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "1koxa",
+                          "name": "ico2",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "music",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-secondary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "is7Uy",
+                          "name": "txt2",
+                          "fill": "$text-primary",
+                          "content": "가사 재생",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Ujf4y",
+                          "name": "spc2",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "BPkr9",
+                          "name": "chv2",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Kzfb2",
+                      "name": "catItem3-Display",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "KksIw",
+                          "name": "ico3",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "type",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-secondary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "AsI67",
+                          "name": "txt3",
+                          "fill": "$text-primary",
+                          "content": "표시",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "LZk2k",
+                          "name": "spc3",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "6c5QV",
+                          "name": "chv3",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "UUq1w",
+              "name": "Account Section",
+              "width": "fill_container",
+              "fill": "#FFFFFF00",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "kGine",
+                  "name": "accountLabel",
+                  "fill": "$text-secondary",
+                  "content": "계정 관리",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "frame",
+                  "id": "O9qPB",
+                  "name": "Account List",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": "$bg-primary",
+                  "cornerRadius": 24,
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "kv2b5",
+                      "name": "accItem1",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "HxZG5",
+                          "name": "accIco1",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "user-pen",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-secondary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "tTIme",
+                          "name": "accTxt1",
+                          "fill": "$text-primary",
+                          "content": "프로필 수정",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "4jxai",
+                          "name": "accSpacer1",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "cwCNA",
+                          "name": "accChev1",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "jOld9",
+                      "x": 0,
+                      "y": 54,
+                      "name": "accDiv1",
+                      "enabled": false,
+                      "fill": "$border-default",
+                      "width": "fill_container(362)",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "s49wL",
+                      "name": "accItem2",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "PcWqG",
+                          "name": "accIco2",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "lock",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-secondary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Uadgr",
+                          "name": "accTxt2",
+                          "fill": "$text-primary",
+                          "content": "비밀번호 변경",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "pW88D",
+                          "name": "accSpacer2",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "oi0lU",
+                          "name": "accChev2",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-muted"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "e0Xoh",
+              "name": "logoutBtn",
+              "fill": "$text-muted",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "로그아웃",
+              "textAlign": "center",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "500"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "4lGcj",
+          "name": "Tab Bar Container",
+          "width": "fill_container",
+          "padding": [
+            12,
+            21,
+            21,
+            21
+          ],
+          "justifyContent": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "PV7Wk",
+              "name": "Pill",
+              "width": "fill_container",
+              "height": 62,
+              "fill": "$bg-primary",
+              "cornerRadius": 100,
+              "stroke": {
+                "thickness": 0
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000012",
+                "offset": {
+                  "x": 0,
+                  "y": 2
+                },
+                "blur": 8
+              },
+              "padding": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "SSxVK",
+                  "name": "Home Tab",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "cornerRadius": 26,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "V7F2p",
+                      "name": "tab1Ico",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "house",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "jhq4A",
+                      "name": "tab1Lbl",
+                      "fill": "$text-muted",
+                      "content": "HOME",
+                      "fontFamily": "Inter",
+                      "fontSize": 10,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "5iBAW",
+                  "name": "Words Tab",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "cornerRadius": 26,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ZXbyQ",
+                      "name": "tab2Ico",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "book-open",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "gLOt8",
+                      "name": "tab2Lbl",
+                      "fill": "$text-muted",
+                      "content": "WORDS",
+                      "fontFamily": "Inter",
+                      "fontSize": 10,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Ob4uM",
+                  "name": "My Tab - Active",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "$accent-primary",
+                  "cornerRadius": 26,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "KnVeH",
+                      "name": "tab3Ico",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "user",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFFFFF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "i8uq2",
+                      "name": "tab3Lbl",
+                      "fill": "#FFFFFF",
+                      "content": "MY",
+                      "fontFamily": "Inter",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "6YzPl",
+      "x": 861,
+      "y": 6020,
+      "name": "7b. Settings - 암기",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "$bg-card",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "ZMRZ1",
+          "name": "Status Bar",
+          "width": "fill_container",
+          "height": 62,
+          "padding": [
+            20,
+            24,
+            0,
+            24
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "zCUMK",
+              "name": "timeL",
+              "fill": "$text-primary",
+              "content": "9:41",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "0I7fQ",
+              "name": "iconsR",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "HfhV9",
+                  "name": "sig",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "signal",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "edqXl",
+                  "name": "wifi",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "wifi",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "KQzQk",
+                  "name": "bat",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "battery-full",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "qMAwk",
+          "name": "Header",
+          "width": "fill_container",
+          "height": 48,
+          "gap": 12,
+          "padding": [
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "YhabI",
+              "name": "backIco",
+              "width": 24,
+              "height": 24,
+              "iconFontName": "chevron-left",
+              "iconFontFamily": "lucide",
+              "fill": "$text-primary"
+            },
+            {
+              "type": "text",
+              "id": "Xv3Dq",
+              "name": "headerTitle",
+              "fill": "$text-primary",
+              "content": "암기",
+              "fontFamily": "Inter",
+              "fontSize": 17,
+              "fontWeight": "600"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "WEcdD",
+          "name": "Content Wrapper",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            16,
+            12,
+            24,
+            12
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "evOIh",
+              "name": "Settings Card",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$bg-primary",
+              "cornerRadius": 24,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "pyRTm",
+                  "name": "Retention Setting",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": [
+                    16,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "DkYgz",
+                      "name": "retHeader",
+                      "width": "fill_container",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "H8I4R",
+                          "name": "retIco",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "target",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-secondary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Vb61W",
+                          "name": "retLabel",
+                          "fill": "$text-primary",
+                          "content": "목표 기억률",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "LocRF",
+                          "name": "retSpacer",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "text",
+                          "id": "UTcGr",
+                          "name": "retVal",
+                          "fill": "$accent-primary",
+                          "content": "0.90",
+                          "fontFamily": "Plus Jakarta Sans",
+                          "fontSize": 15,
+                          "fontWeight": "800"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "UTrAT",
+                      "name": "retDesc",
+                      "fill": "$text-muted",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "FSRS 알고리즘의 목표 기억 유지율입니다. 높을수록 복습 주기가 짧아집니다.",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CwJ69",
+                      "name": "Slider",
+                      "width": "fill_container",
+                      "height": 28,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 2,
+                          "id": "dXlyF",
+                          "x": 0,
+                          "y": 12,
+                          "name": "sliderBg",
+                          "fill": "$bg-elevated",
+                          "width": 322,
+                          "height": 4
+                        },
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 2,
+                          "id": "sRdqE",
+                          "x": 0,
+                          "y": 12,
+                          "name": "sliderFill",
+                          "fill": "$accent-primary",
+                          "width": 280,
+                          "height": 4
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "tVh9z",
+                          "x": 272,
+                          "y": 6,
+                          "name": "sliderThumb",
+                          "fill": "#FFFFFF",
+                          "width": 16,
+                          "height": 16,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#00000040",
+                            "offset": {
+                              "x": 0,
+                              "y": 2
+                            },
+                            "blur": 4
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "wi0fE",
+                      "name": "sliderLabels",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Pxr1E",
+                          "name": "slMin",
+                          "fill": "$text-muted",
+                          "content": "0.70",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "LRqE0",
+                          "name": "slMax",
+                          "fill": "$text-muted",
+                          "content": "0.99",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "Tkd6N",
+                  "name": "divider",
+                  "fill": "$bg-elevated",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "Hcok1",
+                  "name": "Interval Setting",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    16,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ZTYrD",
+                      "name": "intIco",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "timer",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-secondary"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "5r7Ny",
+                      "name": "intTextWrap",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Ma0bk",
+                          "name": "intLabel",
+                          "fill": "$text-primary",
+                          "content": "다음 복습 시점 노출",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "YdAp6",
+                          "name": "intDesc",
+                          "fill": "$text-muted",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "플래시카드 선택지에 다음 복습 예정일을 표시합니다",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Q8ioZ",
+                      "name": "Toggle",
+                      "width": 48,
+                      "height": 28,
+                      "fill": "$accent-green",
+                      "cornerRadius": 20,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "gXBm1",
+                          "x": 22,
+                          "y": 2,
+                          "name": "knob",
+                          "fill": "#FFFFFF",
+                          "width": 24,
+                          "height": 24,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#00000030",
+                            "offset": {
+                              "x": 0,
+                              "y": 1
+                            },
+                            "blur": 3
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "Zfds4",
+      "x": 1323,
+      "y": 6020,
+      "name": "7c. Settings - 가사 재생",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "$bg-card",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "UmXla",
+          "name": "Status Bar",
+          "width": "fill_container",
+          "height": 62,
+          "padding": [
+            20,
+            24,
+            0,
+            24
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "00Oll",
+              "name": "tm",
+              "fill": "$text-primary",
+              "content": "9:41",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "pEnfe",
+              "name": "iconsR",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "BjNBI",
+                  "name": "s1",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "signal",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "ARhpw",
+                  "name": "w1",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "wifi",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "t1hpq",
+                  "name": "b1",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "battery-full",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "s0gMT",
+          "name": "Header",
+          "width": "fill_container",
+          "height": 48,
+          "gap": 12,
+          "padding": [
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "WVtDM",
+              "name": "bk",
+              "width": 24,
+              "height": 24,
+              "iconFontName": "chevron-left",
+              "iconFontFamily": "lucide",
+              "fill": "$text-primary"
+            },
+            {
+              "type": "text",
+              "id": "Sc5F0",
+              "name": "ht",
+              "fill": "$text-primary",
+              "content": "가사 재생",
+              "fontFamily": "Inter",
+              "fontSize": 17,
+              "fontWeight": "600"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "XbkI8",
+          "name": "Content Wrapper",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            16,
+            12,
+            24,
+            12
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "PTteO",
+              "name": "Settings Card",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$bg-primary",
+              "cornerRadius": 24,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "o1qN6",
+                  "name": "Furigana Setting",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    16,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "kH0rR",
+                      "name": "i1",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "languages",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-secondary"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xwIc0",
+                      "name": "furiTextWrap",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "h23zQ",
+                          "name": "l1",
+                          "fill": "$text-primary",
+                          "content": "후리가나 표시",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "axI6Q",
+                          "name": "d1",
+                          "fill": "$text-muted",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "재생 화면에서 한자 위에 히라가나 읽기를 표시합니다",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Guim1",
+                      "name": "Toggle",
+                      "width": 48,
+                      "height": 28,
+                      "fill": "$accent-green",
+                      "cornerRadius": 20,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "oOXzc",
+                          "x": 22,
+                          "y": 2,
+                          "name": "kn1",
+                          "fill": "#FFFFFF",
+                          "width": 24,
+                          "height": 24,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#00000030",
+                            "offset": {
+                              "x": 0,
+                              "y": 1
+                            },
+                            "blur": 3
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rectangle",
+                  "id": "TPhHU",
+                  "name": "divider",
+                  "fill": "$bg-elevated",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "GPE9K",
+                  "name": "Korean Pronunciation Setting",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    16,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "KV44S",
+                      "name": "i2",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "speech",
+                      "iconFontFamily": "lucide",
+                      "fill": "$text-secondary"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "TRYG5",
+                      "name": "korTextWrap",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "cpdUL",
+                          "name": "l2",
+                          "fill": "$text-primary",
+                          "content": "한국어 발음 표시",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "mLuON",
+                          "name": "d2",
+                          "fill": "$text-muted",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "재생 화면에서 가사의 한국어 발음을 표시합니다",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "7SF5Y",
+                      "name": "Toggle",
+                      "width": 48,
+                      "height": 28,
+                      "fill": "$accent-green",
+                      "cornerRadius": 20,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "vCVZp",
+                          "x": 22,
+                          "y": 2,
+                          "name": "kn2",
+                          "fill": "#FFFFFF",
+                          "width": 24,
+                          "height": 24,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#00000030",
+                            "offset": {
+                              "x": 0,
+                              "y": 1
+                            },
+                            "blur": 3
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "HwdE5",
+      "x": 1785,
+      "y": 6020,
+      "name": "7d. Settings - 표시",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "$bg-card",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "7gT4Z",
+          "name": "Status Bar",
+          "width": "fill_container",
+          "height": 62,
+          "padding": [
+            20,
+            24,
+            0,
+            24
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "8SnWE",
+              "name": "tm",
+              "fill": "$text-primary",
+              "content": "9:41",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "2YRfv",
+              "name": "iconsR",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "4gBfK",
+                  "name": "s1",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "signal",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "BE6Ho",
+                  "name": "w1",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "wifi",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "dh4K8",
+                  "name": "b1",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "battery-full",
+                  "iconFontFamily": "lucide",
+                  "fill": "$text-primary"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "8cJyJ",
+          "name": "Header",
+          "width": "fill_container",
+          "height": 48,
+          "gap": 12,
+          "padding": [
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "0NLb4",
+              "name": "bk",
+              "width": 24,
+              "height": 24,
+              "iconFontName": "chevron-left",
+              "iconFontFamily": "lucide",
+              "fill": "$text-primary"
+            },
+            {
+              "type": "text",
+              "id": "5M0Pt",
+              "name": "ht",
+              "fill": "$text-primary",
+              "content": "표시",
+              "fontFamily": "Inter",
+              "fontSize": 17,
+              "fontWeight": "600"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "M2Zu0",
+          "name": "Content Wrapper",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            16,
+            12,
+            24,
+            12
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "jro4Q",
+              "name": "Settings Card",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$bg-primary",
+              "cornerRadius": 24,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "eTrK2",
+                  "name": "Reading Display Setting",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": [
+                    16,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "zoxM3",
+                      "name": "rdHeader",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "nAmf9",
+                          "name": "rdIco",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "type",
+                          "iconFontFamily": "lucide",
+                          "fill": "$text-secondary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "JkjmE",
+                          "name": "rdLabel",
+                          "fill": "$text-primary",
+                          "content": "읽기 표기 방식",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "8Uyuz",
+                      "name": "rdDesc",
+                      "fill": "$text-muted",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "단어의 읽기(발음)를 어떤 문자로 표시할지 선택합니다. 재생 화면과 복습 화면 모두에 적용됩니다.",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "1S26k",
+                      "name": "readingOptions",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "5BWXD",
+                          "name": "opt-katakana",
+                          "width": "fill_container",
+                          "fill": "$accent-primary",
+                          "cornerRadius": 12,
+                          "padding": [
+                            10,
+                            0
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "SdtP0",
+                              "name": "opt1t",
+                              "fill": "#FFFFFF",
+                              "content": "カタカナ",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vqvZI",
+                          "name": "opt-hiragana",
+                          "width": "fill_container",
+                          "fill": "$bg-card",
+                          "cornerRadius": 12,
+                          "padding": [
+                            10,
+                            0
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "PTks9",
+                              "name": "opt2t",
+                              "fill": "$text-secondary",
+                              "content": "ひらがな",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "UBOeA",
+                          "name": "opt-korean",
+                          "width": "fill_container",
+                          "fill": "$bg-card",
+                          "cornerRadius": 12,
+                          "padding": [
+                            10,
+                            0
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "tMpyE",
+                              "name": "opt3t",
+                              "fill": "$text-secondary",
+                              "content": "한국어",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "variables": {

--- a/app-rn/src/api/client.ts
+++ b/app-rn/src/api/client.ts
@@ -13,22 +13,28 @@ client.interceptors.request.use(async (config) => {
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
-  console.log(`[API REQ] ${config.method?.toUpperCase()} ${config.baseURL}${config.url}`, config.data ? JSON.stringify(config.data) : '');
+  if (__DEV__) {
+    console.log(`[API REQ] ${config.method?.toUpperCase()} ${config.baseURL}${config.url}`, config.data ?? '');
+  }
   return config;
 });
 
 client.interceptors.response.use(
   (response) => {
-    console.log(`[API RES] ${response.config.method?.toUpperCase()} ${response.config.url} → ${response.status}`);
+    if (__DEV__) {
+      console.log(`[API RES] ${response.config.method?.toUpperCase()} ${response.config.url} → ${response.status}`);
+    }
     return response;
   },
   (error) => {
-    if (error.response) {
-      console.error(`[API ERR] ${error.config?.method?.toUpperCase()} ${error.config?.url} → ${error.response.status}`, JSON.stringify(error.response.data));
-    } else if (error.request) {
-      console.error(`[API ERR] ${error.config?.method?.toUpperCase()} ${error.config?.url} → No response received. ${error.message}`, `code=${error.code}`);
-    } else {
-      console.error(`[API ERR] Request setup failed: ${error.message}`);
+    if (__DEV__) {
+      if (error.response) {
+        console.error(`[API ERR] ${error.config?.method?.toUpperCase()} ${error.config?.url} → ${error.response.status}`, error.response.data);
+      } else if (error.request) {
+        console.error(`[API ERR] ${error.config?.method?.toUpperCase()} ${error.config?.url} → No response received. ${error.message}`, `code=${error.code}`);
+      } else {
+        console.error(`[API ERR] Request setup failed: ${error.message}`);
+      }
     }
     return Promise.reject(error);
   },

--- a/app-rn/src/api/wordApi.ts
+++ b/app-rn/src/api/wordApi.ts
@@ -1,9 +1,14 @@
 import client from './client';
-import { WordDetailResponse, WordListResponse, AddWordRequest, UpdateWordRequest } from '../types/word';
+import { WordDetailResponse, WordListResponse, AddWordRequest, BatchAddWordRequest, BatchAddWordResponse, UpdateWordRequest } from '../types/word';
 
 export const wordApi = {
   async addWord(req: AddWordRequest): Promise<{ id: number }> {
     const { data } = await client.post<{ id: number }>('/api/words', req);
+    return data;
+  },
+
+  async batchAddWords(req: BatchAddWordRequest): Promise<BatchAddWordResponse> {
+    const { data } = await client.post<BatchAddWordResponse>('/api/words/batch', req);
     return data;
   },
 

--- a/app-rn/src/components/FlashcardView.tsx
+++ b/app-rn/src/components/FlashcardView.tsx
@@ -2,6 +2,8 @@ import React, { useState, useCallback } from 'react';
 import { View, Text, ScrollView, StyleSheet, NativeSyntheticEvent, NativeScrollEvent, useWindowDimensions } from 'react-native';
 import { FlashcardDTO } from '../types/flashcard';
 import { Colors } from '../theme/theme';
+import { convertReading } from '../utils/readingConverter';
+import { useSettingsStore } from '../stores/settingsStore';
 import { JlptBadge, PosBadge } from './Badges';
 import ArtworkImage from './ArtworkImage';
 
@@ -14,6 +16,7 @@ interface Props {
  * Kanji is rendered separately by ReviewScreen to keep its position fixed.
  */
 export default function FlashcardBackDetails({ card }: Props) {
+  const readingDisplay = useSettingsStore(s => s.readingDisplay);
   const { width: screenWidth } = useWindowDimensions();
   const pageWidth = screenWidth - 48;
   const [activeIndex, setActiveIndex] = useState(0);
@@ -25,7 +28,7 @@ export default function FlashcardBackDetails({ card }: Props) {
 
   return (
     <View style={styles.container}>
-      {card.reading && <Text style={styles.reading}>{card.reading}</Text>}
+      {card.reading && <Text style={styles.reading}>{convertReading(card.reading, readingDisplay)}</Text>}
 
       {card.meanings.length > 0 && (
         <View style={styles.badgesRow}>

--- a/app-rn/src/components/LyricLine.tsx
+++ b/app-rn/src/components/LyricLine.tsx
@@ -3,8 +3,12 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Token, StudyUnit } from '../types/song';
 import { POS_INFO } from '../types/pos';
 import { Colors } from '../theme/theme';
+import { useSettingsStore } from '../stores/settingsStore';
+import { katakanaToHiragana } from '../utils/readingConverter';
 
 const NO_UNDERLINE_POS = new Set(['SYMBOL', 'SUPPLEMENTARY_SYMBOL', 'WHITESPACE']);
+
+const KANJI_RE = /[\u4e00-\u9fff]/;
 
 function getUnderlineColor(pos: string): string | null {
   if (NO_UNDERLINE_POS.has(pos)) return null;
@@ -18,12 +22,27 @@ interface Props {
 }
 
 export default function LyricLine({ studyUnit, isActive, onTokenPress }: Props) {
+  const showKoreanPronunciation = useSettingsStore(s => s.showKoreanPronunciation);
+  const showFurigana = useSettingsStore(s => s.showFurigana);
   const textStyle = isActive ? styles.tokenTextActive : styles.tokenTextInactive;
+  const furiganaStyle = isActive ? styles.furiganaActive : styles.furiganaInactive;
+
+  const needsFurigana = (token: Token) =>
+    showFurigana && token.reading && KANJI_RE.test(token.surface);
 
   const renderToken = (token: Token, ti: number) => {
     const underlineColor = getUnderlineColor(token.partOfSpeech);
+    const furigana = needsFurigana(token) ? katakanaToHiragana(token.reading!) : null;
 
     if (!underlineColor) {
+      if (furigana) {
+        return (
+          <View key={ti} style={styles.furiganaWrapper}>
+            <Text style={furiganaStyle}>{furigana}</Text>
+            <Text style={textStyle}>{token.surface}</Text>
+          </View>
+        );
+      }
       return <Text key={ti} style={textStyle}>{token.surface}</Text>;
     }
 
@@ -34,6 +53,7 @@ export default function LyricLine({ studyUnit, isActive, onTokenPress }: Props) 
         activeOpacity={0.6}
       >
         <View style={styles.tokenWithUnderline}>
+          {furigana && <Text style={furiganaStyle}>{furigana}</Text>}
           <Text style={textStyle}>{token.surface}</Text>
           <View style={[styles.underline, { backgroundColor: underlineColor, opacity: isActive ? 1 : 0.35 }]} />
         </View>
@@ -75,7 +95,7 @@ export default function LyricLine({ studyUnit, isActive, onTokenPress }: Props) 
   return (
     <View style={styles.container}>
       <View style={styles.tokensRow}>{renderTokens()}</View>
-      {studyUnit.koreanPronounciation && (
+      {showKoreanPronunciation && studyUnit.koreanPronounciation && (
         <Text style={isActive ? styles.pronActive : styles.pronInactive}>
           {studyUnit.koreanPronounciation}
         </Text>
@@ -112,6 +132,7 @@ const styles = StyleSheet.create({
   },
   tokenWithUnderline: {
     position: 'relative',
+    alignItems: 'center',
   },
   underline: {
     position: 'absolute',
@@ -120,6 +141,19 @@ const styles = StyleSheet.create({
     right: 0,
     height: 2,
     borderRadius: 1,
+  },
+  furiganaWrapper: {
+    alignItems: 'center',
+  },
+  furiganaActive: {
+    fontSize: 10,
+    color: Colors.textSecondary,
+    textAlign: 'center',
+  },
+  furiganaInactive: {
+    fontSize: 10,
+    color: Colors.textMuted,
+    textAlign: 'center',
   },
   pronActive: {
     fontSize: 12,

--- a/app-rn/src/components/LyricLine.tsx
+++ b/app-rn/src/components/LyricLine.tsx
@@ -19,25 +19,28 @@ interface Props {
   studyUnit: StudyUnit;
   isActive: boolean;
   onTokenPress: (token: Token, lineText: string, koreanLyrics: string | null) => void;
-  onLinePress?: () => void;
+  onLineSeek?: (ms: number) => void;
 }
 
-export default function LyricLine({ studyUnit, isActive, onTokenPress, onLinePress }: Props) {
+function LyricLine({ studyUnit, isActive, onTokenPress, onLineSeek }: Props) {
   const showKoreanPronunciation = useSettingsStore(s => s.showKoreanPronunciation);
   const showFurigana = useSettingsStore(s => s.showFurigana);
   const textStyle = isActive ? styles.tokenTextActive : styles.tokenTextInactive;
   const furiganaStyle = isActive ? styles.furiganaActive : styles.furiganaInactive;
   const flashOpacity = useRef(new Animated.Value(0)).current;
 
+  const canSeek = onLineSeek != null && studyUnit.startTimeMs != null;
+
   const handleLinePress = useCallback(() => {
+    if (!onLineSeek || studyUnit.startTimeMs == null) return;
     flashOpacity.setValue(0.10);
     Animated.timing(flashOpacity, {
       toValue: 0,
       duration: 400,
       useNativeDriver: true,
     }).start();
-    onLinePress?.();
-  }, [onLinePress, flashOpacity]);
+    onLineSeek(studyUnit.startTimeMs);
+  }, [onLineSeek, studyUnit.startTimeMs, flashOpacity]);
 
   const needsFurigana = (token: Token) =>
     showFurigana && token.reading && KANJI_RE.test(token.surface);
@@ -105,8 +108,8 @@ export default function LyricLine({ studyUnit, isActive, onTokenPress, onLinePre
   };
 
   return (
-    <Pressable style={styles.container} onPress={onLinePress ? handleLinePress : undefined} disabled={!onLinePress}>
-      {onLinePress && (
+    <Pressable style={styles.container} onPress={canSeek ? handleLinePress : undefined} disabled={!canSeek}>
+      {canSeek && (
         <Animated.View
           style={[styles.flashOverlay, { backgroundColor: Colors.textMuted, opacity: flashOpacity }]}
           pointerEvents="none"
@@ -126,6 +129,8 @@ export default function LyricLine({ studyUnit, isActive, onTokenPress, onLinePre
     </Pressable>
   );
 }
+
+export default React.memo(LyricLine);
 
 const styles = StyleSheet.create({
   container: {

--- a/app-rn/src/components/RatingButtonRow.tsx
+++ b/app-rn/src/components/RatingButtonRow.tsx
@@ -14,7 +14,7 @@ const RATINGS = [
   { rating: 4, label: '쉬움', color: Colors.ratingEasy, bg: Colors.ratingEasyBg },
 ];
 
-export default function RatingButtonRow({ intervals, onRate }: Props) {
+function RatingButtonRow({ intervals, onRate }: Props) {
   return (
     <View style={styles.row}>
       {RATINGS.map(({ rating, label, color, bg }) => (
@@ -35,6 +35,8 @@ export default function RatingButtonRow({ intervals, onRate }: Props) {
     </View>
   );
 }
+
+export default React.memo(RatingButtonRow);
 
 const styles = StyleSheet.create({
   row: { flexDirection: 'row', gap: 8 },

--- a/app-rn/src/components/ReadingText.tsx
+++ b/app-rn/src/components/ReadingText.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Text, TextProps } from 'react-native';
+import { useSettingsStore } from '../stores/settingsStore';
+import { convertReading } from '../utils/readingConverter';
+
+interface Props extends TextProps {
+  reading: string;
+}
+
+function ReadingText({ reading, ...textProps }: Props) {
+  const readingDisplay = useSettingsStore(s => s.readingDisplay);
+  return <Text {...textProps}>{convertReading(reading, readingDisplay)}</Text>;
+}
+
+export default React.memo(ReadingText);

--- a/app-rn/src/components/SongWordListSheet.tsx
+++ b/app-rn/src/components/SongWordListSheet.tsx
@@ -202,11 +202,17 @@ export default function SongWordListSheet({
             return (
               <TouchableOpacity
                 key={pos}
-                style={[styles.filterChip, isOn && styles.filterChipActive]}
+                style={[
+                  styles.filterChip,
+                  isOn && { backgroundColor: info.color + '20' },
+                ]}
                 onPress={() => togglePOS(pos)}
                 activeOpacity={0.7}
               >
-                <Text style={[styles.filterChipText, isOn && styles.filterChipTextActive]}>
+                <Text style={[
+                  styles.filterChipText,
+                  isOn && { color: info.color },
+                ]}>
                   {info.korean}
                 </Text>
               </TouchableOpacity>
@@ -214,18 +220,18 @@ export default function SongWordListSheet({
           })}
         </ScrollView>
 
-        {/* Select all / Deselect all */}
+        {/* Select all checkbox + count */}
         <View style={styles.selectionBar}>
+          <TouchableOpacity
+            style={[styles.checkbox, checkedCount === filteredWords.length && filteredWords.length > 0 && styles.checkboxChecked]}
+            onPress={checkedCount === filteredWords.length ? deselectAll : selectAll}
+            activeOpacity={0.6}
+          >
+            {checkedCount === filteredWords.length && filteredWords.length > 0 && (
+              <Feather name="check" size={14} color="#FFFFFF" />
+            )}
+          </TouchableOpacity>
           <Text style={styles.selectionCount}>{filteredWords.length}개 단어</Text>
-          <View style={styles.selectionActions}>
-            <TouchableOpacity onPress={selectAll} activeOpacity={0.6}>
-              <Text style={styles.selectionLink}>전체 선택</Text>
-            </TouchableOpacity>
-            <Text style={styles.selectionDot}>·</Text>
-            <TouchableOpacity onPress={deselectAll} activeOpacity={0.6}>
-              <Text style={styles.selectionLink}>전체 해제</Text>
-            </TouchableOpacity>
-          </View>
         </View>
 
         {/* Word list */}
@@ -309,16 +315,10 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     backgroundColor: Colors.card,
   },
-  filterChipActive: {
-    backgroundColor: Colors.primary,
-  },
   filterChipText: {
     fontSize: 13,
     fontWeight: '600',
     color: Colors.textSecondary,
-  },
-  filterChipTextActive: {
-    color: '#FFFFFF',
   },
 
   // Selection bar
@@ -333,20 +333,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '500',
     color: Colors.textSecondary,
-  },
-  selectionActions: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  selectionLink: {
-    fontSize: 13,
-    fontWeight: '500',
-    color: Colors.primary,
-  },
-  selectionDot: {
-    fontSize: 13,
-    color: Colors.textMuted,
   },
 
   // Word list

--- a/app-rn/src/components/SongWordListSheet.tsx
+++ b/app-rn/src/components/SongWordListSheet.tsx
@@ -1,0 +1,441 @@
+import React, { useState, useMemo, useCallback } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  Modal,
+  ActivityIndicator,
+  StyleSheet,
+  ScrollView,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Feather } from '@expo/vector-icons';
+import { StudyUnit } from '../types/song';
+import { AddWordRequest } from '../types/word';
+import { POS_INFO } from '../types/pos';
+import { Colors } from '../theme/theme';
+
+interface UniqueWord {
+  baseForm: string;
+  reading: string;
+  koreanText: string | null;
+  partOfSpeech: string;
+  lineText: string;
+  koreanLyrics: string | null;
+}
+
+interface Props {
+  visible: boolean;
+  studyUnits: StudyUnit[];
+  songId: number;
+  batchAddStatus: string;
+  batchSavedCount: number;
+  batchSkippedCount: number;
+  onSave: (words: AddWordRequest[]) => void;
+  onClose: () => void;
+}
+
+const DEFAULT_ON_POS = new Set(['NOUN', 'VERB', 'ADJECTIVE', 'NA_ADJECTIVE', 'ADVERB']);
+const HIDDEN_POS = new Set(['SYMBOL', 'SUPPLEMENTARY_SYMBOL', 'WHITESPACE']);
+
+// POS categories visible in filter chips (ordered)
+const FILTER_POS_ORDER = [
+  'NOUN', 'VERB', 'ADJECTIVE', 'NA_ADJECTIVE', 'ADVERB',
+  'PRONOUN', 'AUXILIARY_VERB', 'CONJUNCTION', 'ADNOMINAL',
+  'INTERJECTION', 'PARTICLE', 'PREFIX', 'SUFFIX',
+];
+
+export default function SongWordListSheet({
+  visible,
+  studyUnits,
+  songId,
+  batchAddStatus,
+  batchSavedCount,
+  batchSkippedCount,
+  onSave,
+  onClose,
+}: Props) {
+  const { top: safeTop, bottom: safeBottom } = useSafeAreaInsets();
+  const [enabledPOS, setEnabledPOS] = useState<Set<string>>(() => new Set(DEFAULT_ON_POS));
+  const [uncheckedWords, setUncheckedWords] = useState<Set<string>>(new Set());
+
+  // Flatten and dedup tokens by baseForm
+  const allUniqueWords = useMemo(() => {
+    const map = new Map<string, UniqueWord>();
+    for (const unit of studyUnits) {
+      for (const token of unit.tokens) {
+        if (HIDDEN_POS.has(token.partOfSpeech)) continue;
+        if (token.koreanText == null) continue;
+        if (map.has(token.baseForm)) continue;
+        map.set(token.baseForm, {
+          baseForm: token.baseForm,
+          reading: token.baseFormReading ?? token.reading ?? '',
+          koreanText: token.koreanText,
+          partOfSpeech: token.partOfSpeech,
+          lineText: unit.originalText,
+          koreanLyrics: unit.koreanLyrics,
+        });
+      }
+    }
+    return Array.from(map.values());
+  }, [studyUnits]);
+
+  // POS types that actually exist in the words
+  const availablePOS = useMemo(() => {
+    const posSet = new Set(allUniqueWords.map(w => w.partOfSpeech));
+    return FILTER_POS_ORDER.filter(pos => posSet.has(pos));
+  }, [allUniqueWords]);
+
+  // Filtered words by POS
+  const filteredWords = useMemo(
+    () => allUniqueWords.filter(w => enabledPOS.has(w.partOfSpeech)),
+    [allUniqueWords, enabledPOS],
+  );
+
+  // Checked words (visible minus unchecked)
+  const checkedCount = filteredWords.filter(w => !uncheckedWords.has(w.baseForm)).length;
+
+  const togglePOS = useCallback((pos: string) => {
+    setEnabledPOS(prev => {
+      const next = new Set(prev);
+      if (next.has(pos)) {
+        next.delete(pos);
+      } else {
+        next.add(pos);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleWord = useCallback((baseForm: string) => {
+    setUncheckedWords(prev => {
+      const next = new Set(prev);
+      if (next.has(baseForm)) {
+        next.delete(baseForm);
+      } else {
+        next.add(baseForm);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setUncheckedWords(new Set());
+  }, []);
+
+  const deselectAll = useCallback(() => {
+    setUncheckedWords(new Set(filteredWords.map(w => w.baseForm)));
+  }, [filteredWords]);
+
+  const handleSave = useCallback(() => {
+    const words: AddWordRequest[] = filteredWords
+      .filter(w => !uncheckedWords.has(w.baseForm))
+      .map(w => ({
+        japanese: w.baseForm,
+        reading: w.reading,
+        koreanText: w.koreanText ?? '',
+        partOfSpeech: w.partOfSpeech,
+        songId,
+        lyricLine: w.lineText,
+        koreanLyricLine: w.koreanLyrics ?? undefined,
+      }));
+    onSave(words);
+  }, [filteredWords, uncheckedWords, songId, onSave]);
+
+  const renderWordItem = useCallback(({ item }: { item: UniqueWord }) => {
+    const isChecked = !uncheckedWords.has(item.baseForm);
+    const posInfo = POS_INFO[item.partOfSpeech];
+
+    return (
+      <TouchableOpacity
+        style={styles.wordItem}
+        onPress={() => toggleWord(item.baseForm)}
+        activeOpacity={0.6}
+      >
+        <View style={[styles.checkbox, isChecked && styles.checkboxChecked]}>
+          {isChecked && <Feather name="check" size={14} color="#FFFFFF" />}
+        </View>
+        <View style={styles.wordInfo}>
+          <View style={styles.wordTexts}>
+            <Text style={styles.wordJapanese}>{item.baseForm}</Text>
+            {item.reading !== '' && (
+              <Text style={styles.wordReading}>{item.reading}</Text>
+            )}
+          </View>
+          <Text style={styles.wordMeaning} numberOfLines={1}>{item.koreanText}</Text>
+        </View>
+        {posInfo && (
+          <View style={[styles.posBadge, { backgroundColor: posInfo.color + '20' }]}>
+            <Text style={[styles.posBadgeText, { color: posInfo.color }]}>{posInfo.korean}</Text>
+          </View>
+        )}
+      </TouchableOpacity>
+    );
+  }, [uncheckedWords, toggleWord]);
+
+  const isLoading = batchAddStatus === 'loading';
+  const isSuccess = batchAddStatus === 'success';
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View style={[styles.container, { paddingTop: safeTop }]}>
+        {/* Header */}
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>전체 단어</Text>
+          <TouchableOpacity onPress={onClose} activeOpacity={0.6} style={styles.closeBtn}>
+            <Feather name="x" size={22} color={Colors.textPrimary} />
+          </TouchableOpacity>
+        </View>
+
+        {/* POS filter chips */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.filterRow}
+          style={styles.filterScroll}
+        >
+          {availablePOS.map(pos => {
+            const info = POS_INFO[pos];
+            if (!info) return null;
+            const isOn = enabledPOS.has(pos);
+            return (
+              <TouchableOpacity
+                key={pos}
+                style={[styles.filterChip, isOn && styles.filterChipActive]}
+                onPress={() => togglePOS(pos)}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.filterChipText, isOn && styles.filterChipTextActive]}>
+                  {info.korean}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+
+        {/* Select all / Deselect all */}
+        <View style={styles.selectionBar}>
+          <Text style={styles.selectionCount}>{filteredWords.length}개 단어</Text>
+          <View style={styles.selectionActions}>
+            <TouchableOpacity onPress={selectAll} activeOpacity={0.6}>
+              <Text style={styles.selectionLink}>전체 선택</Text>
+            </TouchableOpacity>
+            <Text style={styles.selectionDot}>·</Text>
+            <TouchableOpacity onPress={deselectAll} activeOpacity={0.6}>
+              <Text style={styles.selectionLink}>전체 해제</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        {/* Word list */}
+        <FlatList
+          data={filteredWords}
+          keyExtractor={item => item.baseForm}
+          renderItem={renderWordItem}
+          contentContainerStyle={styles.listContent}
+          style={styles.list}
+        />
+
+        {/* CTA */}
+        <View style={[styles.ctaArea, { paddingBottom: safeBottom + 16 }]}>
+          {isSuccess ? (
+            <View style={[styles.ctaBtn, styles.ctaBtnSuccess]}>
+              <Feather name="check" size={18} color="#FFFFFF" />
+              <Text style={styles.ctaBtnText}>
+                {batchSavedCount}개 저장 완료{batchSkippedCount > 0 ? ` (${batchSkippedCount}개 이미 존재)` : ''}
+              </Text>
+            </View>
+          ) : (
+            <TouchableOpacity
+              style={[styles.ctaBtn, styles.ctaBtnPrimary, checkedCount === 0 && styles.ctaBtnDisabled]}
+              onPress={handleSave}
+              activeOpacity={0.7}
+              disabled={isLoading || checkedCount === 0}
+            >
+              {isLoading ? (
+                <ActivityIndicator color="#FFF" size="small" />
+              ) : (
+                <>
+                  <Feather name="plus" size={18} color="#FFFFFF" />
+                  <Text style={styles.ctaBtnText}>{checkedCount}개 단어 담기</Text>
+                </>
+              )}
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+  },
+  closeBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: Colors.card,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // POS filter
+  filterScroll: {
+    flexGrow: 0,
+  },
+  filterRow: {
+    paddingHorizontal: 20,
+    gap: 8,
+  },
+  filterChip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: Colors.card,
+  },
+  filterChipActive: {
+    backgroundColor: Colors.primary,
+  },
+  filterChipText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: Colors.textSecondary,
+  },
+  filterChipTextActive: {
+    color: '#FFFFFF',
+  },
+
+  // Selection bar
+  selectionBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+  },
+  selectionCount: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: Colors.textSecondary,
+  },
+  selectionActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  selectionLink: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: Colors.primary,
+  },
+  selectionDot: {
+    fontSize: 13,
+    color: Colors.textMuted,
+  },
+
+  // Word list
+  list: {
+    flex: 1,
+  },
+  listContent: {
+    paddingHorizontal: 20,
+  },
+  wordItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: Colors.border,
+  },
+  checkbox: {
+    width: 24,
+    height: 24,
+    borderRadius: 6,
+    borderWidth: 2,
+    borderColor: Colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkboxChecked: {
+    backgroundColor: Colors.primary,
+    borderColor: Colors.primary,
+  },
+  wordInfo: {
+    flex: 1,
+    gap: 2,
+  },
+  wordTexts: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 6,
+  },
+  wordJapanese: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: Colors.textPrimary,
+  },
+  wordReading: {
+    fontSize: 12,
+    color: Colors.textSecondary,
+  },
+  wordMeaning: {
+    fontSize: 13,
+    color: Colors.textSecondary,
+  },
+  posBadge: {
+    borderRadius: 10,
+    paddingVertical: 3,
+    paddingHorizontal: 8,
+  },
+  posBadgeText: {
+    fontSize: 11,
+    fontWeight: '600',
+  },
+
+  // CTA
+  ctaArea: {
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: Colors.border,
+  },
+  ctaBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 52,
+    borderRadius: 26,
+    gap: 8,
+  },
+  ctaBtnPrimary: {
+    backgroundColor: Colors.primary,
+  },
+  ctaBtnSuccess: {
+    backgroundColor: '#10B981',
+  },
+  ctaBtnDisabled: {
+    opacity: 0.4,
+  },
+  ctaBtnText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#FFFFFF',
+  },
+});

--- a/app-rn/src/components/SongWordListSheet.tsx
+++ b/app-rn/src/components/SongWordListSheet.tsx
@@ -14,6 +14,7 @@ import { Feather } from '@expo/vector-icons';
 import { StudyUnit } from '../types/song';
 import { AddWordRequest } from '../types/word';
 import { POS_INFO } from '../types/pos';
+import ReadingText from './ReadingText';
 import { Colors } from '../theme/theme';
 
 interface UniqueWord {
@@ -160,7 +161,7 @@ export default function SongWordListSheet({
           <View style={styles.wordTexts}>
             <Text style={styles.wordJapanese}>{item.baseForm}</Text>
             {item.reading !== '' && (
-              <Text style={styles.wordReading}>{item.reading}</Text>
+              <ReadingText style={styles.wordReading} reading={item.reading} />
             )}
           </View>
           <Text style={styles.wordMeaning} numberOfLines={1}>{item.koreanText}</Text>

--- a/app-rn/src/components/WordAnalysisSheet.tsx
+++ b/app-rn/src/components/WordAnalysisSheet.tsx
@@ -6,6 +6,8 @@ import { Token } from '../types/song';
 import { WordDetailResponse } from '../types/word';
 import { POS_INFO } from '../types/pos';
 import { Colors } from '../theme/theme';
+import { convertReading } from '../utils/readingConverter';
+import { useSettingsStore } from '../stores/settingsStore';
 import ArtworkImage from './ArtworkImage';
 
 interface Props {
@@ -33,6 +35,7 @@ export default function WordAnalysisSheet({
   onEditWord,
   onDeleteWord,
 }: Props) {
+  const readingDisplay = useSettingsStore(s => s.readingDisplay);
   const { width: screenWidth } = useWindowDimensions();
   const examplePageWidth = screenWidth - 48; // 24px padding each side
   const [activeExIndex, setActiveExIndex] = useState(0);
@@ -114,7 +117,7 @@ export default function WordAnalysisSheet({
         <View style={styles.wordRow}>
           <Text style={styles.wordMain}>{token.baseForm}</Text>
           {token.baseFormReading && (
-            <Text style={styles.wordRead}>{token.baseFormReading}</Text>
+            <Text style={styles.wordRead}>{convertReading(token.baseFormReading, readingDisplay)}</Text>
           )}
         </View>
 

--- a/app-rn/src/screens/DeckDetailScreen.tsx
+++ b/app-rn/src/screens/DeckDetailScreen.tsx
@@ -10,6 +10,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useFocusEffect } from '@react-navigation/native';
+import { useShallow } from 'zustand/react/shallow';
 import { useDeckDetailStore } from '../stores/deckDetailStore';
 import ArtworkImage from '../components/ArtworkImage';
 import { Colors, Dimens } from '../theme/theme';
@@ -19,7 +20,9 @@ type Props = NativeStackScreenProps<RootStackParamList, 'DeckDetail'>;
 
 export default function DeckDetailScreen({ route, navigation }: Props) {
   const { songId } = route.params;
-  const { status, data, error, load } = useDeckDetailStore();
+  const { status, data, error, load } = useDeckDetailStore(
+    useShallow(s => ({ status: s.status, data: s.data, error: s.error, load: s.load })),
+  );
 
   useFocusEffect(
     useCallback(() => {

--- a/app-rn/src/screens/DeckWordListScreen.tsx
+++ b/app-rn/src/screens/DeckWordListScreen.tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useFocusEffect } from '@react-navigation/native';
+import { useShallow } from 'zustand/react/shallow';
 import { useDeckWordListStore } from '../stores/deckWordListStore';
 import { useDeckDetailStore } from '../stores/deckDetailStore';
 import { convertReading } from '../utils/readingConverter';
@@ -24,7 +25,15 @@ type Props = NativeStackScreenProps<RootStackParamList, 'DeckWordList'>;
 export default function DeckWordListScreen({ route, navigation }: Props) {
   const { songId } = route.params;
   const readingDisplay = useSettingsStore(s => s.readingDisplay);
-  const { status, words, isLoadingMore, load, loadMore } = useDeckWordListStore();
+  const { status, words, isLoadingMore, load, loadMore } = useDeckWordListStore(
+    useShallow(s => ({
+      status: s.status,
+      words: s.words,
+      isLoadingMore: s.isLoadingMore,
+      load: s.load,
+      loadMore: s.loadMore,
+    })),
+  );
   const deckDetail = useDeckDetailStore((s) => s.data);
   const headerTitle = deckDetail?.title || 'Words';
 

--- a/app-rn/src/screens/DeckWordListScreen.tsx
+++ b/app-rn/src/screens/DeckWordListScreen.tsx
@@ -13,6 +13,8 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useFocusEffect } from '@react-navigation/native';
 import { useDeckWordListStore } from '../stores/deckWordListStore';
 import { useDeckDetailStore } from '../stores/deckDetailStore';
+import { convertReading } from '../utils/readingConverter';
+import { useSettingsStore } from '../stores/settingsStore';
 import { Colors, Dimens } from '../theme/theme';
 import { DeckWordItem } from '../types/deck';
 import { RootStackParamList } from '../navigation/AppNavigator';
@@ -21,6 +23,7 @@ type Props = NativeStackScreenProps<RootStackParamList, 'DeckWordList'>;
 
 export default function DeckWordListScreen({ route, navigation }: Props) {
   const { songId } = route.params;
+  const readingDisplay = useSettingsStore(s => s.readingDisplay);
   const { status, words, isLoadingMore, load, loadMore } = useDeckWordListStore();
   const deckDetail = useDeckDetailStore((s) => s.data);
   const headerTitle = deckDetail?.title || 'Words';
@@ -46,7 +49,7 @@ export default function DeckWordListScreen({ route, navigation }: Props) {
       >
         <View style={styles.headingRow}>
           <Text style={styles.japanese}>{item.japanese}</Text>
-          <Text style={styles.reading}>({item.reading})</Text>
+          <Text style={styles.reading}>({convertReading(item.reading, readingDisplay)})</Text>
         </View>
         <Text style={styles.korean}>{item.meanings.map(m => m.text).join(', ')}</Text>
       </TouchableOpacity>

--- a/app-rn/src/screens/LoginScreen.tsx
+++ b/app-rn/src/screens/LoginScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useShallow } from 'zustand/react/shallow';
 import { useAuthStore } from '../stores/authStore';
 import { Colors, Dimens } from '../theme/theme';
 import { RootStackParamList } from '../navigation/AppNavigator';
@@ -21,7 +22,9 @@ export default function LoginScreen({ navigation }: Props) {
   const [name, setName] = useState('');
   const [password, setPassword] = useState('');
   const [isSignup, setIsSignup] = useState(false);
-  const { status, error, login, signup, reset } = useAuthStore();
+  const { status, error, login, signup, reset } = useAuthStore(
+    useShallow(s => ({ status: s.status, error: s.error, login: s.login, signup: s.signup, reset: s.reset })),
+  );
 
   useEffect(() => {
     if (status === 'success') {

--- a/app-rn/src/screens/PlayerScreen.tsx
+++ b/app-rn/src/screens/PlayerScreen.tsx
@@ -26,6 +26,7 @@ import Animated, {
   runOnJS,
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { useShallow } from 'zustand/react/shallow';
 import { usePlayerStore } from '../stores/playerStore';
 import { useVocabularyStore } from '../stores/vocabularyStore';
 import { songApi } from '../api/songApi';
@@ -54,8 +55,26 @@ const CONTROLS_FADE = 200;
 const CONTROLS_HIDE_DELAY = 3000;
 
 export default function PlayerScreen({ navigation }: Props) {
-  const { studyData, reset: resetPlayer } = usePlayerStore();
-  const vocabStore = useVocabularyStore();
+  const studyData = usePlayerStore(s => s.studyData);
+  const resetPlayer = usePlayerStore(s => s.reset);
+  const {
+    addStatus, getWordStatus, existingWord,
+    batchAddStatus, batchSavedCount, batchSkippedCount,
+  } = useVocabularyStore(
+    useShallow(s => ({
+      addStatus: s.addStatus,
+      getWordStatus: s.getWordStatus,
+      existingWord: s.existingWord,
+      batchAddStatus: s.batchAddStatus,
+      batchSavedCount: s.batchSavedCount,
+      batchSkippedCount: s.batchSkippedCount,
+    })),
+  );
+  const resetLookup = useVocabularyStore(s => s.resetLookup);
+  const getWord = useVocabularyStore(s => s.getWord);
+  const vocabAddWord = useVocabularyStore(s => s.addWord);
+  const resetBatchAdd = useVocabularyStore(s => s.resetBatchAdd);
+  const batchAddWords = useVocabularyStore(s => s.batchAddWords);
 
   const [currentMs, setCurrentMs] = useState(0);
   const [durationMs, setDurationMs] = useState(0);
@@ -318,14 +337,14 @@ export default function PlayerScreen({ navigation }: Props) {
     [],
   );
 
-  const handleTokenPress = (token: Token, lineText: string, koreanLyrics: string | null) => {
+  const handleTokenPress = useCallback((token: Token, lineText: string, koreanLyrics: string | null) => {
     setSelectedToken(token);
     setSelectedLine(lineText);
     setSelectedKoreanLine(koreanLyrics);
-    vocabStore.resetLookup();
-    vocabStore.getWord(token.baseForm);
+    resetLookup();
+    getWord(token.baseForm);
     wordSheetRef.current?.expand();
-  };
+  }, [resetLookup, getWord]);
 
   const handleSeek = useCallback((ms: number) => {
     setCurrentMs(ms);
@@ -341,7 +360,7 @@ export default function PlayerScreen({ navigation }: Props) {
 
   const handleAddWord = () => {
     if (selectedToken) {
-      vocabStore.addWord(selectedToken, song.id, selectedLine, selectedKoreanLine);
+      vocabAddWord(selectedToken, song.id, selectedLine, selectedKoreanLine);
     }
   };
 
@@ -359,14 +378,14 @@ export default function PlayerScreen({ navigation }: Props) {
   };
 
   const handleEditWord = () => {
-    if (vocabStore.existingWord) {
+    if (existingWord) {
       wordSheetRef.current?.close();
       navigation.navigate('EditWord', {
         mode: 'edit',
-        wordId: vocabStore.existingWord.id,
-        japanese: vocabStore.existingWord.japanese,
-        reading: vocabStore.existingWord.reading ?? undefined,
-        meanings: vocabStore.existingWord.meanings,
+        wordId: existingWord.id,
+        japanese: existingWord.japanese,
+        reading: existingWord.reading ?? undefined,
+        meanings: existingWord.meanings,
       });
     }
   };
@@ -378,12 +397,12 @@ export default function PlayerScreen({ navigation }: Props) {
   };
 
   const confirmDeleteWord = async () => {
-    if (vocabStore.existingWord) {
+    if (existingWord) {
       try {
-        await wordApi.deleteWord(vocabStore.existingWord.id);
-        vocabStore.resetLookup();
+        await wordApi.deleteWord(existingWord.id);
+        resetLookup();
         if (selectedToken) {
-          vocabStore.getWord(selectedToken.baseForm);
+          getWord(selectedToken.baseForm);
         }
         setShowDeleteDialog(false);
       } catch {
@@ -392,31 +411,40 @@ export default function PlayerScreen({ navigation }: Props) {
     }
   };
 
-  const hasAnalyzedTokens = studyUnits.some(u => u.tokens.some(t => t.koreanText != null));
+  const hasAnalyzedTokens = useMemo(
+    () => studyUnits.some(u => u.tokens.some(t => t.koreanText != null)),
+    [studyUnits],
+  );
 
   const handleOpenWordList = useCallback(() => {
-    vocabStore.resetBatchAdd();
+    resetBatchAdd();
     setWordListVisible(true);
   }, []);
 
   const handleBatchSave = useCallback((words: AddWordRequest[]) => {
-    vocabStore.batchAddWords(words);
+    batchAddWords(words);
   }, []);
 
   const handleCloseWordList = useCallback(() => {
     setWordListVisible(false);
   }, []);
 
-  const isTranslationPending = studyUnits.length > 0
-    && studyUnits.some(u => u.originalText.trim() !== '')
-    && studyUnits.every(u => u.koreanLyrics === null);
+  const isTranslationPending = useMemo(
+    () => studyUnits.length > 0
+      && studyUnits.some(u => u.originalText.trim() !== '')
+      && studyUnits.every(u => u.koreanLyrics === null),
+    [studyUnits],
+  );
 
-  const currentLineIndex = isSynced
-    ? studyUnits.reduce((acc, unit, idx) => {
-        if (unit.startTimeMs != null && unit.startTimeMs <= currentMs) return idx;
-        return acc;
-      }, 0)
-    : -1;
+  const currentLineIndex = useMemo(
+    () => isSynced
+      ? studyUnits.reduce((acc, unit, idx) => {
+          if (unit.startTimeMs != null && unit.startTimeMs <= currentMs) return idx;
+          return acc;
+        }, 0)
+      : -1,
+    [isSynced, studyUnits, currentMs],
+  );
 
   currentLineIndexRef.current = currentLineIndex;
   isPlayingRef.current = isPlaying;
@@ -442,7 +470,7 @@ export default function PlayerScreen({ navigation }: Props) {
         studyUnit={item}
         isActive={!isSynced || index === currentLineIndex}
         onTokenPress={handleTokenPress}
-        onLinePress={isSynced && item.startTimeMs != null ? () => handleSeek(item.startTimeMs!) : undefined}
+        onLineSeek={isSynced ? handleSeek : undefined}
       />
     </View>
   );
@@ -608,9 +636,9 @@ export default function PlayerScreen({ navigation }: Props) {
           {selectedToken && (
             <WordAnalysisSheet
               token={selectedToken}
-              addStatus={vocabStore.addStatus}
-              getWordStatus={vocabStore.getWordStatus}
-              existingWord={vocabStore.existingWord}
+              addStatus={addStatus}
+              getWordStatus={getWordStatus}
+              existingWord={existingWord}
               songId={song.id}
               lyricLine={selectedLine}
               onAddWord={handleAddWord}
@@ -656,9 +684,9 @@ export default function PlayerScreen({ navigation }: Props) {
         visible={wordListVisible}
         studyUnits={studyUnits}
         songId={song.id}
-        batchAddStatus={vocabStore.batchAddStatus}
-        batchSavedCount={vocabStore.batchSavedCount}
-        batchSkippedCount={vocabStore.batchSkippedCount}
+        batchAddStatus={batchAddStatus}
+        batchSavedCount={batchSavedCount}
+        batchSkippedCount={batchSkippedCount}
         onSave={handleBatchSave}
         onClose={handleCloseWordList}
       />

--- a/app-rn/src/screens/PlayerScreen.tsx
+++ b/app-rn/src/screens/PlayerScreen.tsx
@@ -32,9 +32,11 @@ import { songApi } from '../api/songApi';
 import { wordApi } from '../api/wordApi';
 import YouTubePlayer, { YouTubePlayerRef } from '../components/YouTubePlayer';
 import WordAnalysisSheet from '../components/WordAnalysisSheet';
+import SongWordListSheet from '../components/SongWordListSheet';
 import LyricLine from '../components/LyricLine';
 import SeekBar from '../components/SeekBar';
 import { Token, StudyUnit } from '../types/song';
+import { AddWordRequest } from '../types/word';
 import { Colors } from '../theme/theme';
 import { RootStackParamList } from '../navigation/AppNavigator';
 
@@ -61,6 +63,7 @@ export default function PlayerScreen({ navigation }: Props) {
   const [selectedToken, setSelectedToken] = useState<Token | null>(null);
   const [selectedLine, setSelectedLine] = useState('');
   const [selectedKoreanLine, setSelectedKoreanLine] = useState<string | null>(null);
+  const [wordListVisible, setWordListVisible] = useState(false);
   const youtubeRef = useRef<YouTubePlayerRef>(null);
   const wordSheetRef = useRef<BottomSheet>(null);
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
@@ -348,6 +351,21 @@ export default function PlayerScreen({ navigation }: Props) {
     }
   };
 
+  const hasAnalyzedTokens = studyUnits.some(u => u.tokens.some(t => t.koreanText != null));
+
+  const handleOpenWordList = useCallback(() => {
+    vocabStore.resetBatchAdd();
+    setWordListVisible(true);
+  }, []);
+
+  const handleBatchSave = useCallback((words: AddWordRequest[]) => {
+    vocabStore.batchAddWords(words);
+  }, []);
+
+  const handleCloseWordList = useCallback(() => {
+    setWordListVisible(false);
+  }, []);
+
   const isTranslationPending = studyUnits.length > 0
     && studyUnits.some(u => u.originalText.trim() !== '')
     && studyUnits.every(u => u.koreanLyrics === null);
@@ -437,6 +455,16 @@ export default function PlayerScreen({ navigation }: Props) {
                 <View style={styles.songInfo}>
                   <Text style={styles.songTitle}>{song.title}</Text>
                   <Text style={styles.songArtist}>{song.artist}</Text>
+                  {hasAnalyzedTokens && (
+                    <TouchableOpacity
+                      style={styles.wordListBtn}
+                      onPress={handleOpenWordList}
+                      activeOpacity={0.7}
+                    >
+                      <Feather name="list" size={16} color={Colors.primary} />
+                      <Text style={styles.wordListBtnText}>전체 단어 담기</Text>
+                    </TouchableOpacity>
+                  )}
                   {isTranslationPending && (
                     <View style={styles.notice}>
                       <View style={[styles.noticeIconWrap, { backgroundColor: Colors.elevated }]}>
@@ -556,6 +584,18 @@ export default function PlayerScreen({ navigation }: Props) {
         </View>
       </Modal>
     </SafeAreaView>
+
+      {/* Song word list sheet */}
+      <SongWordListSheet
+        visible={wordListVisible}
+        studyUnits={studyUnits}
+        songId={song.id}
+        batchAddStatus={vocabStore.batchAddStatus}
+        batchSavedCount={vocabStore.batchSavedCount}
+        batchSkippedCount={vocabStore.batchSkippedCount}
+        onSave={handleBatchSave}
+        onClose={handleCloseWordList}
+      />
     </View>
   );
 }
@@ -690,6 +730,22 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '500',
     color: Colors.textSecondary,
+  },
+  wordListBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    gap: 6,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 20,
+    backgroundColor: Colors.primary + '12',
+    marginTop: 8,
+  },
+  wordListBtnText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: Colors.primary,
   },
 
   // Notices

--- a/app-rn/src/screens/ReviewScreen.tsx
+++ b/app-rn/src/screens/ReviewScreen.tsx
@@ -14,6 +14,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useFocusEffect } from '@react-navigation/native';
 import { Feather } from '@expo/vector-icons';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useShallow } from 'zustand/react/shallow';
 import { useReviewStore } from '../stores/reviewStore';
 import FlashcardBackDetails from '../components/FlashcardView';
 import RatingButtonRow from '../components/RatingButtonRow';
@@ -30,7 +31,16 @@ export default function ReviewScreen({ route, navigation }: Props) {
     status, cards, currentIndex, isRevealed, totalCount,
     stats, totalReviewed, ratingCounts, error,
     loadDueCards, reveal, rate, refreshCurrentCard,
-  } = useReviewStore();
+  } = useReviewStore(
+    useShallow(s => ({
+      status: s.status, cards: s.cards, currentIndex: s.currentIndex,
+      isRevealed: s.isRevealed, totalCount: s.totalCount,
+      stats: s.stats, totalReviewed: s.totalReviewed,
+      ratingCounts: s.ratingCounts, error: s.error,
+      loadDueCards: s.loadDueCards, reveal: s.reveal,
+      rate: s.rate, refreshCurrentCard: s.refreshCurrentCard,
+    })),
+  );
 
   useEffect(() => {
     loadDueCards(songId);

--- a/app-rn/src/screens/SearchScreen.tsx
+++ b/app-rn/src/screens/SearchScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useShallow } from 'zustand/react/shallow';
 import { useSearchStore } from '../stores/searchStore';
 import { usePlayerStore } from '../stores/playerStore';
 import SongListItem from '../components/SongListItem';
@@ -28,8 +29,17 @@ function formatDuration(seconds: number): string {
 export default function SearchScreen({ navigation }: Props) {
   const [query, setQuery] = useState('');
   const insets = useSafeAreaInsets();
-  const { searchStatus, items, isLoadingMore, search, loadMore } = useSearchStore();
-  const { status: playerStatus, analyze } = usePlayerStore();
+  const { searchStatus, items, isLoadingMore, search, loadMore } = useSearchStore(
+    useShallow(s => ({
+      searchStatus: s.searchStatus,
+      items: s.items,
+      isLoadingMore: s.isLoadingMore,
+      search: s.search,
+      loadMore: s.loadMore,
+    })),
+  );
+  const playerStatus = usePlayerStore(s => s.status);
+  const analyze = usePlayerStore(s => s.analyze);
 
   const handleAnalyze = useCallback(async (item: Parameters<typeof analyze>[0]) => {
     await analyze(item);

--- a/app-rn/src/screens/tabs/HomeTab.tsx
+++ b/app-rn/src/screens/tabs/HomeTab.tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Feather } from '@expo/vector-icons';
+import { useShallow } from 'zustand/react/shallow';
 import { useHomeStore } from '../../stores/homeStore';
 import { usePlayerStore } from '../../stores/playerStore';
 import SongCard from '../../components/SongCard';
@@ -24,8 +25,11 @@ const PAGE_SIZE = 9;
 
 export default function HomeTab() {
   const navigation = useNavigation<Nav>();
-  const { status, songs, load } = useHomeStore();
-  const { status: playerStatus, loadById } = usePlayerStore();
+  const { status, songs, load } = useHomeStore(
+    useShallow(s => ({ status: s.status, songs: s.songs, load: s.load })),
+  );
+  const playerStatus = usePlayerStore(s => s.status);
+  const loadById = usePlayerStore(s => s.loadById);
 
   useFocusEffect(
     useCallback(() => {

--- a/app-rn/src/screens/tabs/MyPageTab.tsx
+++ b/app-rn/src/screens/tabs/MyPageTab.tsx
@@ -13,6 +13,7 @@ import Slider from '@react-native-community/slider';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, CommonActions } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useShallow } from 'zustand/react/shallow';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { tokenStorage } from '../../utils/tokenStorage';
 import { Colors, Dimens } from '../../theme/theme';
@@ -25,7 +26,16 @@ export default function MyPageTab() {
   const {
     status, requestRetention, showIntervals, readingDisplay, showKoreanPronunciation, showFurigana, isSaving,
     loadSettings, setRetention, setShowIntervals, setReadingDisplay, setShowKoreanPronunciation, setShowFurigana, save,
-  } = useSettingsStore();
+  } = useSettingsStore(
+    useShallow(s => ({
+      status: s.status, requestRetention: s.requestRetention,
+      showIntervals: s.showIntervals, readingDisplay: s.readingDisplay,
+      showKoreanPronunciation: s.showKoreanPronunciation, showFurigana: s.showFurigana,
+      isSaving: s.isSaving, loadSettings: s.loadSettings, setRetention: s.setRetention,
+      setShowIntervals: s.setShowIntervals, setReadingDisplay: s.setReadingDisplay,
+      setShowKoreanPronunciation: s.setShowKoreanPronunciation, setShowFurigana: s.setShowFurigana, save: s.save,
+    })),
+  );
 
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 

--- a/app-rn/src/screens/tabs/MyPageTab.tsx
+++ b/app-rn/src/screens/tabs/MyPageTab.tsx
@@ -23,8 +23,8 @@ type Nav = NativeStackNavigationProp<RootStackParamList>;
 export default function MyPageTab() {
   const navigation = useNavigation<Nav>();
   const {
-    status, requestRetention, showIntervals, isSaving,
-    loadSettings, setRetention, setShowIntervals, save,
+    status, requestRetention, showIntervals, readingDisplay, isSaving,
+    loadSettings, setRetention, setShowIntervals, setReadingDisplay, save,
   } = useSettingsStore();
 
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -61,6 +61,11 @@ export default function MyPageTab() {
     // Toggle saves immediately (no need to debounce)
     setTimeout(() => save(), 0);
   }, [setShowIntervals, save]);
+
+  const handleReadingDisplayChange = useCallback((value: 'KATAKANA' | 'HIRAGANA' | 'KOREAN') => {
+    setReadingDisplay(value);
+    setTimeout(() => save(), 0);
+  }, [setReadingDisplay, save]);
 
   const handleLogout = async () => {
     await tokenStorage.clearToken();
@@ -149,6 +154,34 @@ export default function MyPageTab() {
               trackColor={{ true: Colors.stateRetrievability, false: Colors.border }}
               thumbColor={Colors.surface}
             />
+          </View>
+        </View>
+
+        {/* Reading Display */}
+        <View style={styles.settingBlock}>
+          <Text style={styles.settingLabel}>읽기 표기 방식</Text>
+          <Text style={styles.settingDescription}>
+            단어의 읽기(발음)를 어떤 문자로 표시할지 선택합니다
+          </Text>
+          <View style={styles.readingOptions}>
+            {(['KATAKANA', 'HIRAGANA', 'KOREAN'] as const).map((opt) => (
+              <TouchableOpacity
+                key={opt}
+                style={[
+                  styles.readingOption,
+                  readingDisplay === opt && styles.readingOptionActive,
+                ]}
+                onPress={() => handleReadingDisplayChange(opt)}
+                activeOpacity={0.7}
+              >
+                <Text style={[
+                  styles.readingOptionText,
+                  readingDisplay === opt && styles.readingOptionTextActive,
+                ]}>
+                  {opt === 'KATAKANA' ? 'カタカナ' : opt === 'HIRAGANA' ? 'ひらがな' : '한국어'}
+                </Text>
+              </TouchableOpacity>
+            ))}
           </View>
         </View>
       </View>
@@ -322,6 +355,31 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: Colors.textMuted,
     marginLeft: 6,
+  },
+
+  // Reading display options
+  readingOptions: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 12,
+  },
+  readingOption: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: Colors.card,
+    alignItems: 'center',
+  },
+  readingOptionActive: {
+    backgroundColor: Colors.primary,
+  },
+  readingOptionText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: Colors.textSecondary,
+  },
+  readingOptionTextActive: {
+    color: '#FFFFFF',
   },
 
   // Logout

--- a/app-rn/src/screens/tabs/MyPageTab.tsx
+++ b/app-rn/src/screens/tabs/MyPageTab.tsx
@@ -23,8 +23,8 @@ type Nav = NativeStackNavigationProp<RootStackParamList>;
 export default function MyPageTab() {
   const navigation = useNavigation<Nav>();
   const {
-    status, requestRetention, showIntervals, readingDisplay, isSaving,
-    loadSettings, setRetention, setShowIntervals, setReadingDisplay, save,
+    status, requestRetention, showIntervals, readingDisplay, showKoreanPronunciation, showFurigana, isSaving,
+    loadSettings, setRetention, setShowIntervals, setReadingDisplay, setShowKoreanPronunciation, setShowFurigana, save,
   } = useSettingsStore();
 
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -61,6 +61,16 @@ export default function MyPageTab() {
     // Toggle saves immediately (no need to debounce)
     setTimeout(() => save(), 0);
   }, [setShowIntervals, save]);
+
+  const handleShowKoreanPronunciationChange = useCallback((value: boolean) => {
+    setShowKoreanPronunciation(value);
+    setTimeout(() => save(), 0);
+  }, [setShowKoreanPronunciation, save]);
+
+  const handleShowFuriganaChange = useCallback((value: boolean) => {
+    setShowFurigana(value);
+    setTimeout(() => save(), 0);
+  }, [setShowFurigana, save]);
 
   const handleReadingDisplayChange = useCallback((value: 'KATAKANA' | 'HIRAGANA' | 'KOREAN') => {
     setReadingDisplay(value);
@@ -182,6 +192,42 @@ export default function MyPageTab() {
                 </Text>
               </TouchableOpacity>
             ))}
+          </View>
+        </View>
+
+        {/* Furigana Toggle */}
+        <View style={styles.settingBlock}>
+          <View style={styles.settingRow}>
+            <View style={styles.settingTextBlock}>
+              <Text style={styles.settingLabel}>후리가나 표시</Text>
+              <Text style={styles.settingDescription}>
+                재생 화면에서 한자 위에 히라가나 읽기를 표시합니다
+              </Text>
+            </View>
+            <Switch
+              value={showFurigana}
+              onValueChange={handleShowFuriganaChange}
+              trackColor={{ true: Colors.stateRetrievability, false: Colors.border }}
+              thumbColor={Colors.surface}
+            />
+          </View>
+        </View>
+
+        {/* Korean Pronunciation Toggle */}
+        <View style={styles.settingBlock}>
+          <View style={styles.settingRow}>
+            <View style={styles.settingTextBlock}>
+              <Text style={styles.settingLabel}>한국어 발음 표시</Text>
+              <Text style={styles.settingDescription}>
+                재생 화면에서 가사의 한국어 발음을 표시합니다
+              </Text>
+            </View>
+            <Switch
+              value={showKoreanPronunciation}
+              onValueChange={handleShowKoreanPronunciationChange}
+              trackColor={{ true: Colors.stateRetrievability, false: Colors.border }}
+              thumbColor={Colors.surface}
+            />
           </View>
         </View>
       </View>

--- a/app-rn/src/screens/tabs/WordTab.tsx
+++ b/app-rn/src/screens/tabs/WordTab.tsx
@@ -11,6 +11,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useShallow } from 'zustand/react/shallow';
 import { useDeckListStore } from '../../stores/deckListStore';
 import { flashcardApi } from '../../api/flashcardApi';
 import SongListItem from '../../components/SongListItem';
@@ -22,7 +23,9 @@ type Nav = NativeStackNavigationProp<RootStackParamList>;
 
 export default function WordTab() {
   const navigation = useNavigation<Nav>();
-  const { status, data, load } = useDeckListStore();
+  const { status, data, load } = useDeckListStore(
+    useShallow(s => ({ status: s.status, data: s.data, load: s.load })),
+  );
   const [stats, setStats] = useState<FlashcardStatsResponse | null>(null);
 
   useFocusEffect(

--- a/app-rn/src/stores/settingsStore.ts
+++ b/app-rn/src/stores/settingsStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { flashcardApi } from '../api/flashcardApi';
+import type { ReadingDisplay } from '../utils/readingConverter';
 
 type SettingsStatus = 'loading' | 'loaded' | 'error';
 
@@ -7,6 +8,7 @@ interface SettingsState {
   status: SettingsStatus;
   requestRetention: number;
   showIntervals: boolean;
+  readingDisplay: ReadingDisplay;
   isSaving: boolean;
   saveSuccess: boolean;
   error: string | null;
@@ -14,6 +16,7 @@ interface SettingsState {
   loadSettings: () => Promise<void>;
   setRetention: (value: number) => void;
   setShowIntervals: (value: boolean) => void;
+  setReadingDisplay: (value: ReadingDisplay) => void;
   save: () => Promise<void>;
 }
 
@@ -21,6 +24,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   status: 'loading',
   requestRetention: 0.9,
   showIntervals: true,
+  readingDisplay: 'KATAKANA',
   isSaving: false,
   saveSuccess: false,
   error: null,
@@ -33,6 +37,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         status: 'loaded',
         requestRetention: settings.requestRetention,
         showIntervals: settings.showIntervals,
+        readingDisplay: settings.readingDisplay,
       });
     } catch (e: any) {
       set({ status: 'error', error: e.message });
@@ -41,12 +46,13 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
 
   setRetention: (value) => set({ requestRetention: value, saveSuccess: false }),
   setShowIntervals: (value) => set({ showIntervals: value, saveSuccess: false }),
+  setReadingDisplay: (value) => set({ readingDisplay: value, saveSuccess: false }),
 
   save: async () => {
-    const { requestRetention, showIntervals } = get();
+    const { requestRetention, showIntervals, readingDisplay } = get();
     set({ isSaving: true, saveSuccess: false });
     try {
-      await flashcardApi.updateSettings({ requestRetention, showIntervals });
+      await flashcardApi.updateSettings({ requestRetention, showIntervals, readingDisplay });
       set({ isSaving: false, saveSuccess: true });
     } catch {
       set({ isSaving: false });

--- a/app-rn/src/stores/settingsStore.ts
+++ b/app-rn/src/stores/settingsStore.ts
@@ -9,6 +9,8 @@ interface SettingsState {
   requestRetention: number;
   showIntervals: boolean;
   readingDisplay: ReadingDisplay;
+  showKoreanPronunciation: boolean;
+  showFurigana: boolean;
   isSaving: boolean;
   saveSuccess: boolean;
   error: string | null;
@@ -17,6 +19,8 @@ interface SettingsState {
   setRetention: (value: number) => void;
   setShowIntervals: (value: boolean) => void;
   setReadingDisplay: (value: ReadingDisplay) => void;
+  setShowKoreanPronunciation: (value: boolean) => void;
+  setShowFurigana: (value: boolean) => void;
   save: () => Promise<void>;
 }
 
@@ -25,6 +29,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   requestRetention: 0.9,
   showIntervals: true,
   readingDisplay: 'KATAKANA',
+  showKoreanPronunciation: true,
+  showFurigana: true,
   isSaving: false,
   saveSuccess: false,
   error: null,
@@ -38,6 +44,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         requestRetention: settings.requestRetention,
         showIntervals: settings.showIntervals,
         readingDisplay: settings.readingDisplay,
+        showKoreanPronunciation: settings.showKoreanPronunciation,
+        showFurigana: settings.showFurigana,
       });
     } catch (e: any) {
       set({ status: 'error', error: e.message });
@@ -47,12 +55,14 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   setRetention: (value) => set({ requestRetention: value, saveSuccess: false }),
   setShowIntervals: (value) => set({ showIntervals: value, saveSuccess: false }),
   setReadingDisplay: (value) => set({ readingDisplay: value, saveSuccess: false }),
+  setShowKoreanPronunciation: (value) => set({ showKoreanPronunciation: value, saveSuccess: false }),
+  setShowFurigana: (value) => set({ showFurigana: value, saveSuccess: false }),
 
   save: async () => {
-    const { requestRetention, showIntervals, readingDisplay } = get();
+    const { requestRetention, showIntervals, readingDisplay, showKoreanPronunciation, showFurigana } = get();
     set({ isSaving: true, saveSuccess: false });
     try {
-      await flashcardApi.updateSettings({ requestRetention, showIntervals, readingDisplay });
+      await flashcardApi.updateSettings({ requestRetention, showIntervals, readingDisplay, showKoreanPronunciation, showFurigana });
       set({ isSaving: false, saveSuccess: true });
     } catch {
       set({ isSaving: false });

--- a/app-rn/src/stores/vocabularyStore.ts
+++ b/app-rn/src/stores/vocabularyStore.ts
@@ -1,16 +1,22 @@
 import { create } from 'zustand';
 import { wordApi } from '../api/wordApi';
-import { WordDetailResponse, WordListItem } from '../types/word';
+import { AddWordRequest, WordDetailResponse, WordListItem } from '../types/word';
 import { Token } from '../types/song';
 
 type AddStatus = 'idle' | 'loading' | 'success' | 'error';
 type GetWordStatus = 'idle' | 'loading' | 'found' | 'notFound' | 'error';
 type WordListStatus = 'idle' | 'loading' | 'success' | 'error';
+type BatchAddStatus = 'idle' | 'loading' | 'success' | 'error';
 
 interface VocabularyState {
   // Add
   addStatus: AddStatus;
   addedId: number | null;
+
+  // Batch add
+  batchAddStatus: BatchAddStatus;
+  batchSavedCount: number;
+  batchSkippedCount: number;
 
   // Get existing word
   getWordStatus: GetWordStatus;
@@ -24,6 +30,8 @@ interface VocabularyState {
 
   getWord: (japanese: string) => Promise<void>;
   addWord: (token: Token, songId: number, lyricLine: string, koreanLyricLine?: string | null) => Promise<void>;
+  batchAddWords: (wordRequests: AddWordRequest[]) => Promise<void>;
+  resetBatchAdd: () => void;
   loadWords: () => Promise<void>;
   loadMoreWords: () => Promise<void>;
   resetLookup: () => void;
@@ -32,6 +40,9 @@ interface VocabularyState {
 export const useVocabularyStore = create<VocabularyState>((set, get) => ({
   addStatus: 'idle',
   addedId: null,
+  batchAddStatus: 'idle',
+  batchSavedCount: 0,
+  batchSkippedCount: 0,
   getWordStatus: 'idle',
   existingWord: null,
   wordListStatus: 'idle',
@@ -70,6 +81,19 @@ export const useVocabularyStore = create<VocabularyState>((set, get) => ({
       set({ addStatus: 'error' });
     }
   },
+
+  batchAddWords: async (wordRequests: AddWordRequest[]) => {
+    set({ batchAddStatus: 'loading' });
+    try {
+      const res = await wordApi.batchAddWords({ words: wordRequests });
+      set({ batchAddStatus: 'success', batchSavedCount: res.savedCount, batchSkippedCount: res.skippedCount });
+    } catch {
+      set({ batchAddStatus: 'error' });
+    }
+  },
+
+  resetBatchAdd: () =>
+    set({ batchAddStatus: 'idle', batchSavedCount: 0, batchSkippedCount: 0 }),
 
   loadWords: async () => {
     set({ wordListStatus: 'loading', words: [], nextCursor: null });

--- a/app-rn/src/types/flashcard.ts
+++ b/app-rn/src/types/flashcard.ts
@@ -40,4 +40,5 @@ export interface ReviewResponse {
 export interface UserSettingsDTO {
   requestRetention: number;
   showIntervals: boolean;
+  readingDisplay: 'KATAKANA' | 'HIRAGANA' | 'KOREAN';
 }

--- a/app-rn/src/types/flashcard.ts
+++ b/app-rn/src/types/flashcard.ts
@@ -41,4 +41,6 @@ export interface UserSettingsDTO {
   requestRetention: number;
   showIntervals: boolean;
   readingDisplay: 'KATAKANA' | 'HIRAGANA' | 'KOREAN';
+  showKoreanPronunciation: boolean;
+  showFurigana: boolean;
 }

--- a/app-rn/src/types/word.ts
+++ b/app-rn/src/types/word.ts
@@ -43,6 +43,15 @@ export interface AddWordRequest {
   koreanLyricLine?: string;
 }
 
+export interface BatchAddWordRequest {
+  words: AddWordRequest[];
+}
+
+export interface BatchAddWordResponse {
+  savedCount: number;
+  skippedCount: number;
+}
+
 export interface UpdateWordRequest {
   reading: string | null;
   meanings: WordMeaning[];

--- a/app-rn/src/utils/readingConverter.ts
+++ b/app-rn/src/utils/readingConverter.ts
@@ -1,0 +1,212 @@
+export type ReadingDisplay = 'KATAKANA' | 'HIRAGANA' | 'KOREAN';
+
+function katakanaToHiragana(text: string): string {
+  let result = '';
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    // カタカナ range: U+30A1 (ァ) ~ U+30F6 (ヶ)
+    if (code >= 0x30a1 && code <= 0x30f6) {
+      result += String.fromCharCode(code - 0x60);
+    } else {
+      result += text[i];
+    }
+  }
+  return result;
+}
+
+// 2-char yōon combinations (must be checked before single chars)
+const YOON_MAP: Record<string, string> = {
+  'キャ': '캬', 'キュ': '큐', 'キョ': '쿄',
+  'シャ': '샤', 'シュ': '슈', 'ショ': '쇼',
+  'チャ': '차', 'チュ': '추', 'チョ': '초',
+  'ニャ': '냐', 'ニュ': '뉴', 'ニョ': '뇨',
+  'ヒャ': '햐', 'ヒュ': '휴', 'ヒョ': '효',
+  'ミャ': '먀', 'ミュ': '뮤', 'ミョ': '묘',
+  'リャ': '랴', 'リュ': '류', 'リョ': '료',
+  'ギャ': '갸', 'ギュ': '규', 'ギョ': '교',
+  'ジャ': '자', 'ジュ': '주', 'ジョ': '조',
+  'ビャ': '뱌', 'ビュ': '뷰', 'ビョ': '뵤',
+  'ピャ': '퍄', 'ピュ': '퓨', 'ピョ': '표',
+};
+
+// Single-char kana mapping
+const KANA_MAP: Record<string, string> = {
+  // vowels
+  'ア': '아', 'イ': '이', 'ウ': '우', 'エ': '에', 'オ': '오',
+  // ka row
+  'カ': '카', 'キ': '키', 'ク': '쿠', 'ケ': '케', 'コ': '코',
+  // sa row
+  'サ': '사', 'シ': '시', 'ス': '스', 'セ': '세', 'ソ': '소',
+  // ta row
+  'タ': '타', 'チ': '치', 'ツ': '츠', 'テ': '테', 'ト': '토',
+  // na row
+  'ナ': '나', 'ニ': '니', 'ヌ': '누', 'ネ': '네', 'ノ': '노',
+  // ha row
+  'ハ': '하', 'ヒ': '히', 'フ': '후', 'ヘ': '헤', 'ホ': '호',
+  // ma row
+  'マ': '마', 'ミ': '미', 'ム': '무', 'メ': '메', 'モ': '모',
+  // ya row
+  'ヤ': '야', 'ユ': '유', 'ヨ': '요',
+  // ra row
+  'ラ': '라', 'リ': '리', 'ル': '루', 'レ': '레', 'ロ': '로',
+  // wa row
+  'ワ': '와', 'ヲ': '오',
+  // dakuten (ga, za, da, ba)
+  'ガ': '가', 'ギ': '기', 'グ': '구', 'ゲ': '게', 'ゴ': '고',
+  'ザ': '자', 'ジ': '지', 'ズ': '즈', 'ゼ': '제', 'ゾ': '조',
+  'ダ': '다', 'ヂ': '지', 'ヅ': '즈', 'デ': '데', 'ド': '도',
+  'バ': '바', 'ビ': '비', 'ブ': '부', 'ベ': '베', 'ボ': '보',
+  // handakuten (pa)
+  'パ': '파', 'ピ': '피', 'プ': '푸', 'ペ': '페', 'ポ': '포',
+  // small kana
+  'ァ': '아', 'ィ': '이', 'ゥ': '우', 'ェ': '에', 'ォ': '오',
+  'ャ': '야', 'ュ': '유', 'ョ': '요',
+};
+
+// Vowel row for each kana (used for long vowel detection)
+type VowelRow = 'a' | 'i' | 'u' | 'e' | 'o';
+
+const VOWEL_ROW: Record<string, VowelRow> = {
+  'ア': 'a', 'カ': 'a', 'サ': 'a', 'タ': 'a', 'ナ': 'a', 'ハ': 'a', 'マ': 'a', 'ヤ': 'a', 'ラ': 'a', 'ワ': 'a',
+  'ガ': 'a', 'ザ': 'a', 'ダ': 'a', 'バ': 'a', 'パ': 'a', 'ァ': 'a', 'ャ': 'a',
+  'イ': 'i', 'キ': 'i', 'シ': 'i', 'チ': 'i', 'ニ': 'i', 'ヒ': 'i', 'ミ': 'i', 'リ': 'i',
+  'ギ': 'i', 'ジ': 'i', 'ヂ': 'i', 'ビ': 'i', 'ピ': 'i', 'ィ': 'i',
+  'ウ': 'u', 'ク': 'u', 'ス': 'u', 'ツ': 'u', 'ヌ': 'u', 'フ': 'u', 'ム': 'u', 'ユ': 'u', 'ル': 'u',
+  'グ': 'u', 'ズ': 'u', 'ヅ': 'u', 'ブ': 'u', 'プ': 'u', 'ゥ': 'u', 'ュ': 'u',
+  'エ': 'e', 'ケ': 'e', 'セ': 'e', 'テ': 'e', 'ネ': 'e', 'ヘ': 'e', 'メ': 'e', 'レ': 'e',
+  'ゲ': 'e', 'ゼ': 'e', 'デ': 'e', 'ベ': 'e', 'ペ': 'e', 'ェ': 'e',
+  'オ': 'o', 'コ': 'o', 'ソ': 'o', 'ト': 'o', 'ノ': 'o', 'ホ': 'o', 'モ': 'o', 'ヨ': 'o', 'ロ': 'o',
+  'ゴ': 'o', 'ゾ': 'o', 'ド': 'o', 'ボ': 'o', 'ポ': 'o', 'ヲ': 'o', 'ォ': 'o', 'ョ': 'o',
+};
+
+// Yōon vowel rows (the combination's vowel is determined by the small kana)
+const YOON_VOWEL: Record<string, VowelRow> = {
+  'キャ': 'a', 'キュ': 'u', 'キョ': 'o',
+  'シャ': 'a', 'シュ': 'u', 'ショ': 'o',
+  'チャ': 'a', 'チュ': 'u', 'チョ': 'o',
+  'ニャ': 'a', 'ニュ': 'u', 'ニョ': 'o',
+  'ヒャ': 'a', 'ヒュ': 'u', 'ヒョ': 'o',
+  'ミャ': 'a', 'ミュ': 'u', 'ミョ': 'o',
+  'リャ': 'a', 'リュ': 'u', 'リョ': 'o',
+  'ギャ': 'a', 'ギュ': 'u', 'ギョ': 'o',
+  'ジャ': 'a', 'ジュ': 'u', 'ジョ': 'o',
+  'ビャ': 'a', 'ビュ': 'u', 'ビョ': 'o',
+  'ピャ': 'a', 'ピュ': 'u', 'ピョ': 'o',
+};
+
+// Which vowel rows each vowel kana can extend as a long vowel
+const LONG_VOWEL_EXTENDS: Record<string, VowelRow[]> = {
+  'ア': ['a'],
+  'イ': ['i', 'e'],  // エ段+イ = long e (e.g., セイ)
+  'ウ': ['u', 'o'],  // オ段+ウ = long o (e.g., コウ)
+  'エ': ['e'],
+  'オ': ['o'],
+};
+
+// 종성 (받침) indices in Korean Unicode block
+const JONGSEONG_NIEUN = 4;  // ㄴ
+const JONGSEONG_SIOT = 19;  // ㅅ
+
+/**
+ * Add a 받침 (final consonant) to a Korean syllable.
+ * Korean syllable = 0xAC00 + (초성*21 + 중성)*28 + 종성
+ * If the char already has 받침 or isn't a Korean syllable, returns null.
+ */
+function addBatchim(char: string, jongseongIndex: number): string | null {
+  const code = char.charCodeAt(0);
+  if (code < 0xac00 || code > 0xd7a3) return null;
+  if ((code - 0xac00) % 28 !== 0) return null; // already has 받침
+  return String.fromCharCode(code + jongseongIndex);
+}
+
+function katakanaToKorean(text: string): string {
+  const result: string[] = [];
+  let prevVowelRow: VowelRow | null = null;
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+
+    // ー (chōon mark) → long vowel
+    if (ch === 'ー') {
+      if (prevVowelRow) {
+        result.push('-');
+      } else {
+        result.push(ch);
+      }
+      // prevVowelRow stays the same (장음 뒤에 또 장음 가능)
+      i++;
+      continue;
+    }
+
+    // Long vowel: vowel kana extending previous syllable's vowel row
+    const extends_ = LONG_VOWEL_EXTENDS[ch];
+    if (extends_ && prevVowelRow && extends_.includes(prevVowelRow)) {
+      result.push('-');
+      // prevVowelRow stays the same
+      i++;
+      continue;
+    }
+
+    // ン → ㄴ 받침 on previous syllable
+    if (ch === 'ン') {
+      if (result.length > 0) {
+        const modified = addBatchim(result[result.length - 1], JONGSEONG_NIEUN);
+        if (modified) {
+          result[result.length - 1] = modified;
+          i++;
+          prevVowelRow = null;
+          continue;
+        }
+      }
+      result.push('ㄴ');
+      i++;
+      prevVowelRow = null;
+      continue;
+    }
+
+    // ッ → ㅅ 받침 on previous syllable (촉음, 외래어표기법)
+    if (ch === 'ッ') {
+      if (result.length > 0) {
+        const modified = addBatchim(result[result.length - 1], JONGSEONG_SIOT);
+        if (modified) {
+          result[result.length - 1] = modified;
+          i++;
+          prevVowelRow = null;
+          continue;
+        }
+      }
+      result.push(ch);
+      i++;
+      prevVowelRow = null;
+      continue;
+    }
+
+    // try 2-char yōon match first
+    if (i + 1 < text.length) {
+      const pair = ch + text[i + 1];
+      if (YOON_MAP[pair]) {
+        result.push(YOON_MAP[pair]);
+        prevVowelRow = YOON_VOWEL[pair] ?? null;
+        i += 2;
+        continue;
+      }
+    }
+
+    // single-char match
+    if (KANA_MAP[ch]) {
+      result.push(KANA_MAP[ch]);
+      prevVowelRow = VOWEL_ROW[ch] ?? null;
+    } else {
+      result.push(ch);
+      prevVowelRow = null;
+    }
+    i++;
+  }
+  return result.join('');
+}
+
+export function convertReading(text: string, display: ReadingDisplay): string {
+  if (display === 'KATAKANA') return text;
+  if (display === 'HIRAGANA') return katakanaToHiragana(text);
+  return katakanaToKorean(text);
+}

--- a/app-rn/src/utils/readingConverter.ts
+++ b/app-rn/src/utils/readingConverter.ts
@@ -1,6 +1,6 @@
 export type ReadingDisplay = 'KATAKANA' | 'HIRAGANA' | 'KOREAN';
 
-function katakanaToHiragana(text: string): string {
+export function katakanaToHiragana(text: string): string {
   let result = '';
   for (let i = 0; i < text.length; i++) {
     const code = text.charCodeAt(i);

--- a/backend/src/main/kotlin/com/japanese/vocabulary/config/converter/JsonListConverter.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/config/converter/JsonListConverter.kt
@@ -1,8 +1,10 @@
 package com.japanese.vocabulary.config.converter
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.japanese.vocabulary.song.dto.AnalyzedLine
 import com.japanese.vocabulary.song.dto.LyricLineData
+import com.japanese.vocabulary.user.dto.UserSettingsData
 import com.japanese.vocabulary.word.dto.WordMeaning
 import jakarta.persistence.AttributeConverter
 import jakarta.persistence.Converter
@@ -33,3 +35,19 @@ class LyricLineDataListConverter : JsonListConverter<LyricLineData>(LyricLineDat
 
 @Converter
 class AnalyzedLineListConverter : JsonListConverter<AnalyzedLine>(AnalyzedLine::class.java)
+
+@Converter
+class UserSettingsJsonConverter : AttributeConverter<UserSettingsData, String> {
+    companion object {
+        private val objectMapper = jacksonObjectMapper()
+    }
+
+    override fun convertToDatabaseColumn(attribute: UserSettingsData?): String {
+        return objectMapper.writeValueAsString(attribute ?: UserSettingsData())
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): UserSettingsData {
+        if (dbData.isNullOrBlank()) return UserSettingsData()
+        return objectMapper.readValue<UserSettingsData>(dbData)
+    }
+}

--- a/backend/src/main/kotlin/com/japanese/vocabulary/flashcard/service/FlashcardService.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/flashcard/service/FlashcardService.kt
@@ -63,9 +63,9 @@ class FlashcardService(
         val songIds = songWordMap.values.flatten().map { it.songId }.toSet()
         val songMap = songRepository.findAllById(songIds).associateBy { it.id }
 
-        val settings = userSettingsRepository.findByUserId(userId)
-        val showIntervals = settings?.showIntervals ?: true
-        val desiredRetention = settings?.requestRetention ?: 0.9
+        val settingsData = userSettingsRepository.findByUserId(userId)?.settings
+        val showIntervals = settingsData?.showIntervals ?: true
+        val desiredRetention = settingsData?.requestRetention ?: 0.9
 
         val cards = dueEntities.mapNotNull { entity ->
             val word = words[entity.wordId] ?: return@mapNotNull null
@@ -127,8 +127,7 @@ class FlashcardService(
             else -> throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Rating must be 1-4")
         }
 
-        val settings = userSettingsRepository.findByUserId(userId)
-        val desiredRetention = settings?.requestRetention ?: 0.9
+        val desiredRetention = userSettingsRepository.findByUserId(userId)?.settings?.requestRetention ?: 0.9
 
         val scheduler = Scheduler.builder()
             .desiredRetention(desiredRetention)

--- a/backend/src/main/kotlin/com/japanese/vocabulary/user/dto/UserSettingsDTO.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/user/dto/UserSettingsDTO.kt
@@ -3,5 +3,7 @@ package com.japanese.vocabulary.user.dto
 data class UserSettingsDTO(
     val requestRetention: Double,
     val showIntervals: Boolean = true,
-    val readingDisplay: String = "KATAKANA"
+    val readingDisplay: String = "KATAKANA",
+    val showKoreanPronunciation: Boolean = true,
+    val showFurigana: Boolean = true
 )

--- a/backend/src/main/kotlin/com/japanese/vocabulary/user/dto/UserSettingsDTO.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/user/dto/UserSettingsDTO.kt
@@ -2,5 +2,6 @@ package com.japanese.vocabulary.user.dto
 
 data class UserSettingsDTO(
     val requestRetention: Double,
-    val showIntervals: Boolean = true
+    val showIntervals: Boolean = true,
+    val readingDisplay: String = "KATAKANA"
 )

--- a/backend/src/main/kotlin/com/japanese/vocabulary/user/dto/UserSettingsData.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/user/dto/UserSettingsData.kt
@@ -3,5 +3,7 @@ package com.japanese.vocabulary.user.dto
 data class UserSettingsData(
     val requestRetention: Double = 0.9,
     val showIntervals: Boolean = true,
-    val readingDisplay: String = "KATAKANA"
+    val readingDisplay: String = "KATAKANA",
+    val showKoreanPronunciation: Boolean = true,
+    val showFurigana: Boolean = true
 )

--- a/backend/src/main/kotlin/com/japanese/vocabulary/user/dto/UserSettingsData.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/user/dto/UserSettingsData.kt
@@ -2,5 +2,6 @@ package com.japanese.vocabulary.user.dto
 
 data class UserSettingsData(
     val requestRetention: Double = 0.9,
-    val showIntervals: Boolean = true
+    val showIntervals: Boolean = true,
+    val readingDisplay: String = "KATAKANA"
 )

--- a/backend/src/main/kotlin/com/japanese/vocabulary/user/dto/UserSettingsData.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/user/dto/UserSettingsData.kt
@@ -1,0 +1,6 @@
+package com.japanese.vocabulary.user.dto
+
+data class UserSettingsData(
+    val requestRetention: Double = 0.9,
+    val showIntervals: Boolean = true
+)

--- a/backend/src/main/kotlin/com/japanese/vocabulary/user/entity/UserSettingsEntity.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/user/entity/UserSettingsEntity.kt
@@ -1,5 +1,7 @@
 package com.japanese.vocabulary.user.entity
 
+import com.japanese.vocabulary.config.converter.UserSettingsJsonConverter
+import com.japanese.vocabulary.user.dto.UserSettingsData
 import jakarta.persistence.*
 
 @Entity
@@ -12,9 +14,7 @@ class UserSettingsEntity(
     @Column(name = "user_id", nullable = false, unique = true)
     val userId: Long,
 
-    @Column(name = "request_retention", nullable = false)
-    var requestRetention: Double = 0.9,
-
-    @Column(name = "show_intervals", nullable = false)
-    var showIntervals: Boolean = true
+    @Column(name = "settings", columnDefinition = "JSON")
+    @Convert(converter = UserSettingsJsonConverter::class)
+    var settings: UserSettingsData = UserSettingsData()
 )

--- a/backend/src/main/kotlin/com/japanese/vocabulary/user/service/UserSettingsService.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/user/service/UserSettingsService.kt
@@ -14,19 +14,31 @@ class UserSettingsService(
     @Transactional(readOnly = true)
     fun getSettings(userId: Long): UserSettingsDTO {
         val data = userSettingsRepository.findByUserId(userId)?.settings ?: UserSettingsData()
-        return UserSettingsDTO(requestRetention = data.requestRetention, showIntervals = data.showIntervals)
+        return UserSettingsDTO(
+            requestRetention = data.requestRetention,
+            showIntervals = data.showIntervals,
+            readingDisplay = data.readingDisplay
+        )
     }
 
     @Transactional
     fun updateSettings(userId: Long, dto: UserSettingsDTO): UserSettingsDTO {
         require(dto.requestRetention in 0.7..0.99) { "requestRetention must be between 0.7 and 0.99" }
+        require(dto.readingDisplay in listOf("KATAKANA", "HIRAGANA", "KOREAN")) {
+            "readingDisplay must be KATAKANA, HIRAGANA, or KOREAN"
+        }
         val entity = userSettingsRepository.findByUserId(userId)
             ?: UserSettingsEntity(userId = userId)
         entity.settings = UserSettingsData(
             requestRetention = dto.requestRetention,
-            showIntervals = dto.showIntervals
+            showIntervals = dto.showIntervals,
+            readingDisplay = dto.readingDisplay
         )
         userSettingsRepository.save(entity)
-        return UserSettingsDTO(requestRetention = entity.settings.requestRetention, showIntervals = entity.settings.showIntervals)
+        return UserSettingsDTO(
+            requestRetention = entity.settings.requestRetention,
+            showIntervals = entity.settings.showIntervals,
+            readingDisplay = entity.settings.readingDisplay
+        )
     }
 }

--- a/backend/src/main/kotlin/com/japanese/vocabulary/user/service/UserSettingsService.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/user/service/UserSettingsService.kt
@@ -1,6 +1,7 @@
 package com.japanese.vocabulary.user.service
 
 import com.japanese.vocabulary.user.dto.UserSettingsDTO
+import com.japanese.vocabulary.user.dto.UserSettingsData
 import com.japanese.vocabulary.user.entity.UserSettingsEntity
 import com.japanese.vocabulary.user.repository.UserSettingsRepository
 import org.springframework.stereotype.Service
@@ -12,19 +13,20 @@ class UserSettingsService(
 ) {
     @Transactional(readOnly = true)
     fun getSettings(userId: Long): UserSettingsDTO {
-        val settings = userSettingsRepository.findByUserId(userId)
-            ?: return UserSettingsDTO(requestRetention = 0.9, showIntervals = true)
-        return UserSettingsDTO(requestRetention = settings.requestRetention, showIntervals = settings.showIntervals)
+        val data = userSettingsRepository.findByUserId(userId)?.settings ?: UserSettingsData()
+        return UserSettingsDTO(requestRetention = data.requestRetention, showIntervals = data.showIntervals)
     }
 
     @Transactional
     fun updateSettings(userId: Long, dto: UserSettingsDTO): UserSettingsDTO {
         require(dto.requestRetention in 0.7..0.99) { "requestRetention must be between 0.7 and 0.99" }
-        val settings = userSettingsRepository.findByUserId(userId)
+        val entity = userSettingsRepository.findByUserId(userId)
             ?: UserSettingsEntity(userId = userId)
-        settings.requestRetention = dto.requestRetention
-        settings.showIntervals = dto.showIntervals
-        userSettingsRepository.save(settings)
-        return UserSettingsDTO(requestRetention = settings.requestRetention, showIntervals = settings.showIntervals)
+        entity.settings = UserSettingsData(
+            requestRetention = dto.requestRetention,
+            showIntervals = dto.showIntervals
+        )
+        userSettingsRepository.save(entity)
+        return UserSettingsDTO(requestRetention = entity.settings.requestRetention, showIntervals = entity.settings.showIntervals)
     }
 }

--- a/backend/src/main/kotlin/com/japanese/vocabulary/user/service/UserSettingsService.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/user/service/UserSettingsService.kt
@@ -17,7 +17,9 @@ class UserSettingsService(
         return UserSettingsDTO(
             requestRetention = data.requestRetention,
             showIntervals = data.showIntervals,
-            readingDisplay = data.readingDisplay
+            readingDisplay = data.readingDisplay,
+            showKoreanPronunciation = data.showKoreanPronunciation,
+            showFurigana = data.showFurigana
         )
     }
 
@@ -32,13 +34,17 @@ class UserSettingsService(
         entity.settings = UserSettingsData(
             requestRetention = dto.requestRetention,
             showIntervals = dto.showIntervals,
-            readingDisplay = dto.readingDisplay
+            readingDisplay = dto.readingDisplay,
+            showKoreanPronunciation = dto.showKoreanPronunciation,
+            showFurigana = dto.showFurigana
         )
         userSettingsRepository.save(entity)
         return UserSettingsDTO(
             requestRetention = entity.settings.requestRetention,
             showIntervals = entity.settings.showIntervals,
-            readingDisplay = entity.settings.readingDisplay
+            readingDisplay = entity.settings.readingDisplay,
+            showKoreanPronunciation = entity.settings.showKoreanPronunciation,
+            showFurigana = entity.settings.showFurigana
         )
     }
 }

--- a/backend/src/main/kotlin/com/japanese/vocabulary/word/controller/WordController.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/word/controller/WordController.kt
@@ -1,6 +1,8 @@
 package com.japanese.vocabulary.word.controller
 
 import com.japanese.vocabulary.word.dto.AddWordRequest
+import com.japanese.vocabulary.word.dto.BatchAddWordRequest
+import com.japanese.vocabulary.word.dto.BatchAddWordResponse
 import com.japanese.vocabulary.word.dto.UpdateWordRequest
 import com.japanese.vocabulary.word.dto.WordDetailResponse
 import com.japanese.vocabulary.word.dto.WordListResponse
@@ -22,6 +24,12 @@ class WordController(
         val userId = currentUserId()
         val wordId = wordService.addWord(userId, request)
         return mapOf("id" to wordId)
+    }
+
+    @PostMapping("/batch")
+    fun batchAddWords(@RequestBody request: BatchAddWordRequest): BatchAddWordResponse {
+        val userId = currentUserId()
+        return wordService.batchAddWords(userId, request)
     }
 
     @GetMapping

--- a/backend/src/main/kotlin/com/japanese/vocabulary/word/dto/BatchAddWordRequest.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/word/dto/BatchAddWordRequest.kt
@@ -1,0 +1,5 @@
+package com.japanese.vocabulary.word.dto
+
+data class BatchAddWordRequest(
+    val words: List<AddWordRequest>
+)

--- a/backend/src/main/kotlin/com/japanese/vocabulary/word/dto/BatchAddWordResponse.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/word/dto/BatchAddWordResponse.kt
@@ -1,0 +1,6 @@
+package com.japanese.vocabulary.word.dto
+
+data class BatchAddWordResponse(
+    val savedCount: Int,
+    val skippedCount: Int
+)

--- a/backend/src/main/kotlin/com/japanese/vocabulary/word/service/WordService.kt
+++ b/backend/src/main/kotlin/com/japanese/vocabulary/word/service/WordService.kt
@@ -28,6 +28,27 @@ class WordService(
     private val eventPublisher: ApplicationEventPublisher
 ) {
     @Transactional
+    fun batchAddWords(userId: Long, request: BatchAddWordRequest): BatchAddWordResponse {
+        var savedCount = 0
+        var skippedCount = 0
+        for (wordRequest in request.words) {
+            val existing = wordRepository.findByUserIdAndJapaneseText(userId, wordRequest.japanese)
+            val newMeaning = WordMeaning(text = wordRequest.koreanText, partOfSpeech = wordRequest.partOfSpeech)
+            val meaningAlreadyExists = existing != null && existing.meanings.any { it.text == newMeaning.text }
+            val songWordExists = existing != null && songWordRepository.existsByWordIdAndSongIdAndLyricLine(
+                existing.id!!, wordRequest.songId, wordRequest.lyricLine
+            )
+            if (meaningAlreadyExists && songWordExists) {
+                skippedCount++
+            } else {
+                addWord(userId, wordRequest)
+                savedCount++
+            }
+        }
+        return BatchAddWordResponse(savedCount = savedCount, skippedCount = skippedCount)
+    }
+
+    @Transactional
     fun addWord(userId: Long, request: AddWordRequest): Long {
         if (!songRepository.existsById(request.songId)) {
             throw ResponseStatusException(HttpStatus.NOT_FOUND, "Song not found: ${request.songId}")

--- a/backend/src/main/resources/db/migration/V14__user_settings_json.sql
+++ b/backend/src/main/resources/db/migration/V14__user_settings_json.sql
@@ -1,0 +1,7 @@
+ALTER TABLE user_settings ADD COLUMN settings JSON NOT NULL DEFAULT ('{}');
+
+UPDATE user_settings
+SET settings = JSON_OBJECT('requestRetention', request_retention, 'showIntervals', show_intervals);
+
+ALTER TABLE user_settings DROP COLUMN request_retention;
+ALTER TABLE user_settings DROP COLUMN show_intervals;


### PR DESCRIPTION
Fixes #12

## Summary
- **Backend**: New `POST /api/words/batch` endpoint that accepts a list of `AddWordRequest` and returns `{savedCount, skippedCount}`. Wraps existing `addWord()` logic in a single transaction, skipping words that already exist with the same meaning and example sentence.
- **Frontend**: New `SongWordListSheet` modal component accessible from the Player screen's song info header. Features:
  - POS filter chips (noun/verb/adjective/na-adjective/adverb ON by default)
  - Word list with checkboxes (all checked by default), showing japanese text, reading, meaning, and POS badge
  - Select all / deselect all controls
  - Batch save CTA button with loading/success states
- Words are deduped by `baseForm` across all lyric lines; only words with Korean translations are shown
- Entry button only appears when lyric analysis is completed (tokens available)

## Test plan
- [ ] Open a song with completed lyric analysis
- [ ] Verify "전체 단어 담기" button appears below artist name
- [ ] Tap button → verify modal opens with all words listed
- [ ] Toggle POS filter chips → verify word list updates
- [ ] Uncheck some words → verify count updates in CTA
- [ ] Tap "전체 선택" / "전체 해제" → verify all checkboxes toggle
- [ ] Tap save → verify words are added to vocabulary
- [ ] Verify already-saved words show as skipped in success message
- [ ] Open a song without completed analysis → verify button is hidden