### PR TITLE
Fix #17: Load user settings on app startup

### DIFF
--- a/app-rn/App.tsx
+++ b/app-rn/App.tsx
@@ -5,6 +5,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import AppNavigator, { RootStackParamList } from './src/navigation/AppNavigator';
 import { tokenStorage } from './src/utils/tokenStorage';
+import { useSettingsStore } from './src/stores/settingsStore';
 import { Colors } from './src/theme/theme';
 
 export default function App() {
@@ -12,6 +13,9 @@ export default function App() {
 
   useEffect(() => {
     tokenStorage.getToken().then((token) => {
+      if (token) {
+        useSettingsStore.getState().loadSettings();
+      }
       setInitialRoute(token ? 'Main' : 'Login');
     });
   }, []);


### PR DESCRIPTION
Fixes #17

## Summary
- Call `useSettingsStore.getState().loadSettings()` in `App.tsx` when a valid token is found, before setting the initial route
- This ensures user preferences (reading display, furigana, Korean pronunciation, etc.) are applied from the first screen render after login
- The existing `loadSettings()` call in `MyPageTab` is preserved as a refresh mechanism

## Test plan
- [ ] Launch app while logged in — verify settings (reading display, furigana toggle, etc.) are applied immediately without visiting the settings page
- [ ] Launch app while logged out — verify no settings API call is made
- [ ] Visit MyPageTab — verify settings still load/refresh correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)