### PR TITLE
Fix #28: Show error alert when lyric search fails

### DIFF
--- a/app-rn/src/screens/SearchScreen.tsx
+++ b/app-rn/src/screens/SearchScreen.tsx
@@ -6,6 +6,7 @@ import {
   FlatList,
   TouchableOpacity,
   ActivityIndicator,
+  Alert,
   StyleSheet,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
@@ -41,8 +42,11 @@ export default function SearchScreen({ navigation }: Props) {
 
   const handleAnalyze = useCallback(async (item: Parameters<typeof analyze>[0]) => {
     await analyze(item);
-    if (usePlayerStore.getState().status === 'success') {
+    const state = usePlayerStore.getState();
+    if (state.status === 'success') {
       navigation.navigate('Player', { origin: 'Home' });
+    } else if (state.status === 'error') {
+      Alert.alert('오류', state.error ?? '가사를 불러오지 못했어요.');
     }
   }, [analyze, navigation]);
 

--- a/app-rn/src/screens/tabs/HomeTab.tsx
+++ b/app-rn/src/screens/tabs/HomeTab.tsx
@@ -5,6 +5,7 @@ import {
   ScrollView,
   TouchableOpacity,
   ActivityIndicator,
+  Alert,
   StyleSheet,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -39,8 +40,11 @@ export default function HomeTab() {
 
   const handleSongPress = useCallback(async (id: number) => {
     await loadById(id);
-    if (usePlayerStore.getState().status === 'success') {
+    const state = usePlayerStore.getState();
+    if (state.status === 'success') {
       navigation.navigate('Player', { origin: 'Home' });
+    } else if (state.status === 'error') {
+      Alert.alert('오류', state.error ?? '노래를 불러오지 못했어요.');
     }
   }, [loadById, navigation]);
 

--- a/app-rn/src/stores/playerStore.ts
+++ b/app-rn/src/stores/playerStore.ts
@@ -30,7 +30,7 @@ export const usePlayerStore = create<PlayerState>((set) => ({
       });
       set({ status: 'success', studyData: data });
     } catch (e: any) {
-      set({ status: 'error', error: e.message });
+      set({ status: 'error', error: e.response?.data?.message ?? e.message });
     }
   },
 
@@ -40,7 +40,7 @@ export const usePlayerStore = create<PlayerState>((set) => ({
       const data = await songApi.getById(id);
       set({ status: 'success', studyData: data });
     } catch (e: any) {
-      set({ status: 'error', error: e.message });
+      set({ status: 'error', error: e.response?.data?.message ?? e.message });
     }
   },
 


### PR DESCRIPTION
Fixes #28

## Summary
- Extract meaningful backend error messages from Axios responses (`e.response?.data?.message`) in `playerStore` instead of using generic Axios messages
- Show `Alert.alert` with the error message in `SearchScreen` and `HomeTab` when lyric analysis or song loading fails
- Uses the same `Alert.alert` pattern already established in `EditWordScreen`

## Test plan
- [ ] Search for a song that has no lyrics available → verify error alert appears with backend message
- [ ] Disconnect network and try loading a recent song from HomeTab → verify error alert appears
- [ ] Search and load a song that works → verify normal navigation to Player still works