### PR TITLE
Persist baseurl in storage across app restarts

### DIFF
--- a/app-rn/App.tsx
+++ b/app-rn/App.tsx
@@ -5,6 +5,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import AppNavigator, { RootStackParamList } from './src/navigation/AppNavigator';
 import { tokenStorage } from './src/utils/tokenStorage';
+import { initBaseURL } from './src/api/client';
 import { useSettingsStore } from './src/stores/settingsStore';
 import { Colors } from './src/theme/theme';
 
@@ -12,12 +13,14 @@ export default function App() {
   const [initialRoute, setInitialRoute] = useState<keyof RootStackParamList | null>(null);
 
   useEffect(() => {
-    tokenStorage.getToken().then((token) => {
-      if (token) {
-        useSettingsStore.getState().loadSettings();
-      }
-      setInitialRoute(token ? 'Main' : 'Login');
-    });
+    initBaseURL().then(() =>
+      tokenStorage.getToken().then((token) => {
+        if (token) {
+          useSettingsStore.getState().loadSettings();
+        }
+        setInitialRoute(token ? 'Main' : 'Login');
+      }),
+    );
   }, []);
 
   if (!initialRoute) {

--- a/app-rn/src/api/client.ts
+++ b/app-rn/src/api/client.ts
@@ -12,8 +12,16 @@ export function getBaseURL(): string {
   return client.defaults.baseURL ?? DEFAULT_BACKEND_URL ?? '';
 }
 
-export function setBaseURL(url: string) {
+export async function initBaseURL(): Promise<void> {
+  const stored = await tokenStorage.getBaseURL();
+  if (stored) {
+    client.defaults.baseURL = stored;
+  }
+}
+
+export async function setBaseURL(url: string) {
   client.defaults.baseURL = url;
+  await tokenStorage.saveBaseURL(url);
 }
 
 client.interceptors.request.use(async (config) => {

--- a/app-rn/src/components/ServerURLEditor.tsx
+++ b/app-rn/src/components/ServerURLEditor.tsx
@@ -10,8 +10,8 @@ interface Props {
 export default function ServerURLEditor({ onApply }: Props) {
   const [url, setUrl] = useState(getBaseURL);
 
-  const handleApply = () => {
-    setBaseURL(url);
+  const handleApply = async () => {
+    await setBaseURL(url);
     onApply?.();
   };
 

--- a/app-rn/src/utils/tokenStorage.ts
+++ b/app-rn/src/utils/tokenStorage.ts
@@ -2,6 +2,7 @@ import { Platform } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 
 const TOKEN_KEY = 'jwt_token';
+const BASE_URL_KEY = 'base_url';
 
 export const tokenStorage = Platform.OS === 'web'
   ? {
@@ -14,6 +15,15 @@ export const tokenStorage = Platform.OS === 'web'
       async clearToken(): Promise<void> {
         localStorage.removeItem(TOKEN_KEY);
       },
+      async getBaseURL(): Promise<string | null> {
+        return localStorage.getItem(BASE_URL_KEY);
+      },
+      async saveBaseURL(url: string): Promise<void> {
+        localStorage.setItem(BASE_URL_KEY, url);
+      },
+      async clearBaseURL(): Promise<void> {
+        localStorage.removeItem(BASE_URL_KEY);
+      },
     }
   : {
       async getToken(): Promise<string | null> {
@@ -24,5 +34,14 @@ export const tokenStorage = Platform.OS === 'web'
       },
       async clearToken(): Promise<void> {
         await SecureStore.deleteItemAsync(TOKEN_KEY);
+      },
+      async getBaseURL(): Promise<string | null> {
+        return SecureStore.getItemAsync(BASE_URL_KEY);
+      },
+      async saveBaseURL(url: string): Promise<void> {
+        await SecureStore.setItemAsync(BASE_URL_KEY, url);
+      },
+      async clearBaseURL(): Promise<void> {
+        await SecureStore.deleteItemAsync(BASE_URL_KEY);
       },
     };


### PR DESCRIPTION
Fixes #33

## Summary
- Add `getBaseURL`/`saveBaseURL`/`clearBaseURL` to `tokenStorage` using the same SecureStore/localStorage pattern as JWT tokens
- Add `initBaseURL()` in `client.ts` to restore persisted baseurl on app startup; `setBaseURL()` now also persists to storage
- Call `initBaseURL()` in `App.tsx` before token check so the correct backend URL is set before any API calls
- Update default `EXPO_PUBLIC_BACKEND_URL` from `:8080` to `/main` (k8s dev server)

## Test plan
- [ ] Set a custom backend URL via ServerURLEditor, close and reopen the app — verify the URL persists
- [ ] Clear app data, launch fresh — verify it falls back to the default URL
- [ ] Verify API calls work correctly with both persisted and default URLs