### PR TITLE
Auto-scroll lyrics during playback

### DIFF
--- a/app-rn/src/screens/PlayerScreen.tsx
+++ b/app-rn/src/screens/PlayerScreen.tsx
@@ -101,6 +101,8 @@ export default function PlayerScreen({ navigation }: Props) {
   const currentLineIndexRef = useRef(-1);
   const isPlayingRef = useRef(false);
   const isSyncedRef = useRef(false);
+  const followModeRef = useRef(true);
+  const prevAutoScrollLineRef = useRef(-1);
 
   const viewabilityConfig = useRef({ itemVisiblePercentThreshold: 50 });
   const onViewableItemsChanged = useRef(({ viewableItems }: { viewableItems: Array<{ index: number | null }> }) => {
@@ -108,6 +110,7 @@ export default function PlayerScreen({ navigation }: Props) {
       viewableItems.filter(v => v.index != null).map(v => v.index!),
     );
     const shouldShow = isSyncedRef.current && isPlayingRef.current
+      && !followModeRef.current
       && currentLineIndexRef.current >= 0
       && !visibleIndicesRef.current.has(currentLineIndexRef.current);
     if (shouldShow !== prevScrollBtnShown.current) {
@@ -126,6 +129,16 @@ export default function PlayerScreen({ navigation }: Props) {
     const offset = y - flatListHeight.current * 0.3;
     flatListRef.current?.scrollToOffset({ offset: Math.max(0, offset), animated: true });
   }, []);
+
+  const handleScrollBeginDrag = useCallback(() => {
+    followModeRef.current = false;
+  }, []);
+
+  const handleScrollBtnPress = useCallback(() => {
+    followModeRef.current = true;
+    prevAutoScrollLineRef.current = currentLineIndexRef.current;
+    scrollToCurrentLine();
+  }, [scrollToCurrentLine]);
 
   const scrollBtnAnimStyle = useAnimatedStyle(() => ({
     opacity: scrollBtnVisible.value,
@@ -458,6 +471,7 @@ export default function PlayerScreen({ navigation }: Props) {
   isSyncedRef.current = isSynced;
 
   const shouldShowScrollBtn = isSynced && isPlaying && currentLineIndex >= 0
+    && !followModeRef.current
     && !visibleIndicesRef.current.has(currentLineIndex);
 
   useEffect(() => {
@@ -466,6 +480,21 @@ export default function PlayerScreen({ navigation }: Props) {
       scrollBtnVisible.value = withTiming(shouldShowScrollBtn ? 1 : 0, { duration: 200 });
     }
   }, [shouldShowScrollBtn]);
+
+  // Auto-scroll: follow mode
+  useEffect(() => {
+    if (followModeRef.current && isSynced && isPlaying && currentLineIndex >= 0
+        && currentLineIndex !== prevAutoScrollLineRef.current) {
+      prevAutoScrollLineRef.current = currentLineIndex;
+      scrollToCurrentLine();
+    }
+  }, [currentLineIndex, isSynced, isPlaying, scrollToCurrentLine]);
+
+  // Reset follow mode when song changes
+  useEffect(() => {
+    followModeRef.current = true;
+    prevAutoScrollLineRef.current = -1;
+  }, [studyData]);
 
   const scrollBtnDirection = useMemo(() => {
     if (!shouldShowScrollBtn || visibleIndicesRef.current.size === 0) return 'down';
@@ -551,6 +580,7 @@ export default function PlayerScreen({ navigation }: Props) {
               keyExtractor={(item) => String(item.index)}
               renderItem={renderLyricLine}
               onLayout={(e) => { flatListHeight.current = e.nativeEvent.layout.height; }}
+              onScrollBeginDrag={handleScrollBeginDrag}
               onViewableItemsChanged={onViewableItemsChanged}
               viewabilityConfig={viewabilityConfig.current}
               ListHeaderComponent={
@@ -632,7 +662,7 @@ export default function PlayerScreen({ navigation }: Props) {
               style={[styles.scrollToLineBtn, scrollBtnAnimStyle]}
               pointerEvents={shouldShowScrollBtn ? 'auto' : 'none'}
             >
-              <TouchableOpacity onPress={scrollToCurrentLine} activeOpacity={0.6} style={styles.scrollToLineBtnInner}>
+              <TouchableOpacity onPress={handleScrollBtnPress} activeOpacity={0.6} style={styles.scrollToLineBtnInner}>
                 <Feather name={scrollBtnDirection === 'up' ? 'chevron-up' : 'chevron-down'} size={20} color="#FFFFFF" />
               </TouchableOpacity>
             </Animated.View>


### PR DESCRIPTION
Fixes #36

## Summary
- Add follow mode that auto-scrolls lyrics to the current playing line as the song progresses
- Detect manual scroll via `onScrollBeginDrag` to exit follow mode, letting users freely browse lyrics
- Repurpose existing floating scroll button to re-enter follow mode (scroll to current line + resume auto-following)
- Hide the scroll button while follow mode is active (auto-scroll keeps current line visible)
- Reset follow mode to ON when song changes

## Test plan
- [ ] Play a synced song — lyrics should auto-scroll to each new line as it plays
- [ ] Manually scroll lyrics away from current line — auto-scroll should stop
- [ ] Floating button appears when current line is off-screen after manual scroll
- [ ] Tap floating button — snaps back to current line and resumes auto-scrolling
- [ ] Switch to a different song — follow mode resets to ON
- [ ] Non-synced lyrics — no auto-scroll, no floating button (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)